### PR TITLE
Pin girder-worker-utils to 0.7.1 to fix devops build

### DIFF
--- a/devops/docker/assets/Dockerfile
+++ b/devops/docker/assets/Dockerfile
@@ -60,7 +60,11 @@ ENV C_FORCE_ROOT=1
 RUN pip install GDAL==$(gdal-config --version)
 
 COPY submodules/girder_worker /worker
-RUN pip install -e /worker \
+
+# Here we have to pin girder-worker-utils because it installs
+# setuptools_scm which isn't compatible with installing packages
+# from a bare directory (not in a git repo).
+RUN pip install -e /worker girder-worker-utils==0.7.1 \
  && pip install -e /worker[girder_io,docker]
 
 RUN sh -c 'SET="girder-worker-config set"                        \


### PR DESCRIPTION
This is a temporary work around, we will need to change how things get installed to support more recent versions of `girder-worker` and `girder-worker-utils`.

@aashish24 This should fix your build issue.