### PR TITLE
Two docker build fix

### DIFF
--- a/devops/docker/assets/Dockerfile
+++ b/devops/docker/assets/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update                                         \
         zlib1g-dev                                         \
  && apt-get build-dep -qy                                  \
         gdal                                               \
- && pip install -U pip                                     \
+ && pip install -U 'pip<10'                                \
  && pip install setuptools                                 \
  && apt-get clean                                          \
  && rm -rf /var/lib/apt/lists/*

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -87,3 +87,5 @@ services:
     build:
       context: ../..
       dockerfile: devops/docker/assets/Dockerfile
+      args:
+        MAKE_PARALLELISM: "${MAKE_PARALLELISM}"


### PR DESCRIPTION
Specify to use Pip 9, which is the version that is compatible with the code base;
Unify docker-compose service build arguments to avoid generating two docker image;