### PR TITLE
Add an annotation layer component and related examples

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,7 @@
 comment: false
 coverage:
   status:
-    default:
-      threshold: 1
-    patch:
+    patch: false
+    project:
       default:
-        threshold: 25
-        only_pulls: true
+        threshold: 5

--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -10,6 +10,13 @@ full-screen-viewport
       :attribution='attribution',
       :opacity='opacity'
     )
+    geojs-annotation-layer(
+      :drawing.sync='drawing',
+      :editing.sync='editing',
+      :editable='true',
+      :annotations.sync='annotations',
+      :initialGeojson='geojson'
+    )
 
   side-panel(
     :top='64',
@@ -18,19 +25,19 @@ full-screen-viewport
     :footer='true',
     :actions='panel.actions',
     @click-toolbar='infoToolbar.open = !infoToolbar.open',
-    @click-action='clickAction'
+    @click-action='drawing = $event'
   )
-    v-expansion-panel
-      v-expansion-panel-content(
-        v-for='itemNumber in panel.items',
-        :key='`item-${itemNumber}`'
-      )
-        div(slot='header') Item {{ itemNumber }}
-        v-card
-          v-card-text.text-xs-center
-            | Expansion panel content for item {{ itemNumber }}
+    v-card(
+      v-for='annotation in annotations',
+      :key='annotation.id()',
+    )
+      v-card-title.py-0
+        span {{ annotation.name() }}
+        v-spacer
+        v-btn(icon, @click='clickDelete(annotation)')
+          v-icon delete
     template(slot='footer')
-      span Side panel footer
+      span {{ this.annotations.length }} annotations
       v-spacer
       v-icon(
         @click='clearItems'
@@ -71,6 +78,9 @@ export default {
   name: 'MapView',
   data() {
     return {
+      annotations: [],
+      drawing: false,
+      editing: false,
       baseLayer: true,
       opacity: 1,
       url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -80,17 +90,22 @@ export default {
         zoom: 4,
       },
       panel: {
-        items: 2,
         toolbar: {
           title: 'Side panel',
           icon: 'info',
         },
         actions: [{
-          name: 'add',
-          icon: 'add_circle',
+          name: 'point',
+          icon: 'adjust',
         }, {
-          name: 'delete',
-          icon: 'remove_circle',
+          name: 'rectangle',
+          icon: 'aspect_ratio',
+        }, {
+          name: 'line',
+          icon: 'timeline',
+        }, {
+          name: 'polygon',
+          icon: 'label_outline',
         }],
         expanded: true,
       },
@@ -100,18 +115,27 @@ export default {
         icon: 'close',
       },
       clicked: null,
+      geojson: {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-73.7569, 42.8495],
+          },
+        }],
+      },
     };
   },
   methods: {
     clickAction(name) {
-      if (name === 'add') {
-        this.panel.items += 1;
-      } else if (name === 'delete') {
-        this.panel.items = Math.max(0, this.panel.items - 1);
-      }
+      this.drawing = name;
     },
     clearItems() {
-      this.panel.items = 0;
+      this.annotations = [];
+    },
+    clickDelete(annotation) {
+      this.annotations = this.annotations.filter(a => a.id() !== annotation.id());
     },
   },
 };

--- a/src/components/geojs/GeojsAnnotationLayer.vue
+++ b/src/components/geojs/GeojsAnnotationLayer.vue
@@ -1,0 +1,134 @@
+<template lang="pug">
+// geojs annotation layer
+</template>
+
+<script>
+import bind from 'lodash-es/bind';
+import forEach from 'lodash-es/forEach';
+import indexOf from 'lodash-es/indexOf';
+import differenceBy from 'lodash-es/differenceBy';
+
+const annotationTypes = ['line', 'point', 'polygon', 'rectangle', 'edit'];
+const stateEvents = ['add', 'update', 'remove'];
+
+export default {
+  props: {
+    labels: {
+      type: Boolean,
+      default: false,
+    },
+    editable: {
+      type: Boolean,
+      default: false,
+    },
+    drawing: {
+      type: [String, Boolean],
+      default: false,
+      validator(value) {
+        return value === false || indexOf(annotationTypes, value) >= 0;
+      },
+    },
+    editing: {
+      type: [Number, Boolean],
+      default: false,
+      validator(value) {
+        return value === false || value >= 0;
+      },
+    },
+    annotations: {
+      type: Array,
+      default: () => [],
+    },
+    initialGeojson: {
+      type: [Object, Array],
+      default: () => Object(),
+    },
+  },
+  data() {
+    return {
+      state: [],
+    };
+  },
+  computed: {
+    activeAnnotation() {
+      return this.$geojsLayer.annotationById(this.editing);
+    },
+    geojson: {
+      cache: false,
+      get() {
+        return this.$geojsLayer.geojson();
+      },
+    },
+  },
+  watch: {
+    drawing() {
+      this.$geojsLayer.mode(this.drawing || null);
+    },
+    state() {
+      this.$emit('update:annotations', this.state);
+    },
+    annotations() {
+      const toRemove = differenceBy(
+        this.$geojsLayer.annotations(), this.annotations,
+        annotation => annotation.id(),
+      );
+      const toAdd = differenceBy(
+        this.annotations, this.$geojsLayer.annotations(),
+        annotation => annotation.id(),
+      );
+      forEach(toRemove, annotation => this.$geojsLayer.removeAnnotation(annotation));
+      forEach(toAdd, annotation => this.$geojsLayer.addAnnotation(annotation));
+    },
+  },
+  mounted() {
+    // This is in place purely for testing because there is no way
+    // in @vue/test-utils to put mocks in place *before* mount is called.
+    //   https://github.com/vuejs/vue-test-utils/issues/560
+    this.$parent = this.$parent || this.$options.testParent;
+
+    if (!this.$parent || !this.$parent.$geojsMap) {
+      throw new Error('Annotation layer must be a child of a GeojsMapViewport');
+    }
+    this.$geojs = this.$parent.$geojs;
+    this.$geojsLayer = this.$parent.$geojsMap.createLayer(
+      'annotation', {
+        showLabels: this.labels,
+        clickToEdit: this.editable,
+      });
+    this.$geojsLayer.geojson(this.initialGeojson);
+    this.state = this.$geojsLayer.annotations();
+    this.$geojsLayer.geoOn(
+      this.$geojs.event.annotation.mode,
+      bind(this.resetAnnotationMode, this),
+    );
+
+    forEach(stateEvents, (event) => {
+      this.$geojsLayer.geoOn(
+        this.$geojs.event.annotation[event],
+        bind(this.resetAnnotationState, this),
+      );
+    });
+  },
+  methods: {
+    resetAnnotationMode() {
+      const mode = this.$geojsLayer.mode() || false;
+      let editing = false;
+
+      this.resetAnnotationState();
+      if (mode === 'edit') {
+        editing = this.$geojsLayer.currentAnnotation.id();
+      }
+
+      if (this.drawing !== mode) {
+        this.$emit('update:drawing', mode);
+      }
+      if (editing !== this.editing) {
+        this.$emit('update:editing', editing);
+      }
+    },
+    resetAnnotationState() {
+      this.state = this.$geojsLayer.annotations();
+    },
+  },
+};
+</script>

--- a/src/components/geojs/index.js
+++ b/src/components/geojs/index.js
@@ -1,8 +1,10 @@
+import GeojsAnnotationLayer from './GeojsAnnotationLayer';
 import GeojsMapViewport from './GeojsMapViewport';
 import GeojsTileLayer from './GeojsTileLayer';
 import bindWatchers from './bindWatchers';
 
 export {
+  GeojsAnnotationLayer,
   GeojsMapViewport,
   GeojsTileLayer,
   bindWatchers,

--- a/test/specs/GeojsAnnotationLayer.spec.js
+++ b/test/specs/GeojsAnnotationLayer.spec.js
@@ -1,0 +1,223 @@
+import geojs from 'geojs';
+import { mount } from '@vue/test-utils';
+import last from 'lodash-es/last';
+
+import GeojsMapViewport from '@/components/geojs/GeojsMapViewport';
+import GeojsAnnotationLayer from '@/components/geojs/GeojsAnnotationLayer';
+
+describe('GeojsAnnotationLayer.vue', () => {
+  let mapWrapper;
+  let interactor;
+  function mountAnnotationLayer(options = {}) {
+    const wrapper = mount(GeojsAnnotationLayer, {
+      testParent: mapWrapper.vm,
+      ...options,
+    });
+    return wrapper;
+  }
+
+  function interact(event, pt, button) {
+    interactor.simulateEvent(
+      event, {
+        map: mapWrapper.vm.$geojsMap.gcsToDisplay(pt),
+        button,
+      },
+    );
+  }
+
+  function click(pt) {
+    interact('mousedown', pt, 'left');
+    interact('mouseup', pt, 'left');
+  }
+
+  function drag(pt1, pt2) {
+    click(pt1);
+    interact('mousemove', pt2, 'left');
+    click(pt2);
+  }
+
+  function doubleclick(pt) {
+    click(pt);
+    click(pt);
+  }
+
+  beforeEach(() => {
+    geojs.util.mockVGLRenderer();
+    sinon.stub(console, 'warn');
+    mapWrapper = mount(GeojsMapViewport);
+    interactor = mapWrapper.vm.$geojsMap.interactor();
+  });
+
+  afterEach(() => {
+    console.warn.restore(); // eslint-disable-line no-console
+    mapWrapper.destroy();
+    geojs.util.restoreVGLRenderer();
+  });
+
+  it('annotation type validation', () => {
+    const drawing = mountAnnotationLayer().vm.$options.props.drawing;
+    expect(drawing.validator('not valid')).to.equal(false);
+  });
+
+  it('annotation editing validation', () => {
+    const editing = mountAnnotationLayer().vm.$options.props.editing;
+    expect(editing.validator(-1)).to.equal(false);
+  });
+
+  it('construct with no annotations', () => {
+    const wrapper = mountAnnotationLayer();
+    expect(wrapper.vm.annotations).to.eql([]);
+    expect(wrapper.vm.geojson).to.eql(null);
+  });
+
+  it('construct with geojson', () => {
+    const wrapper = mountAnnotationLayer({
+      propsData: {
+        initialGeojson: {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 15],
+            },
+          }],
+        },
+      },
+    });
+    expect(wrapper.vm.state.length).to.equal(1);
+  });
+
+  it('draw a point', () => {
+    const wrapper = mount(GeojsAnnotationLayer, {
+      testParent: mapWrapper.vm,
+    });
+    wrapper.setProps({ drawing: 'point' });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('point');
+
+    click({ x: 0, y: 0 });
+
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal(null);
+    expect(wrapper.emitted('update:drawing')).to.eql([[false]]);
+    expect(last(wrapper.emitted('update:annotations'))[0].length).to.equal(1);
+    expect(last(wrapper.emitted('update:annotations'))[0][0].type()).to.equal('point');
+  });
+
+  it('draw a rectangle', () => {
+    const wrapper = mountAnnotationLayer();
+    wrapper.setProps({ drawing: 'rectangle' });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('rectangle');
+
+    drag({ x: 0, y: 0 }, { x: 10, y: 15 });
+
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal(null);
+    expect(wrapper.emitted('update:drawing')).to.eql([[false]]);
+    expect(last(wrapper.emitted('update:annotations'))[0].length).to.equal(1);
+    expect(last(wrapper.emitted('update:annotations'))[0][0].type()).to.equal('rectangle');
+  });
+
+  it('draw a line', () => {
+    const wrapper = mountAnnotationLayer();
+    wrapper.setProps({ drawing: 'line' });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('line');
+
+    drag({ x: 0, y: 0 }, { x: 10, y: 15 });
+    doubleclick({ x: 10, y: 15 });
+
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal(null);
+    expect(wrapper.emitted('update:drawing')).to.eql([[false]]);
+    expect(last(wrapper.emitted('update:annotations'))[0].length).to.equal(1);
+    expect(last(wrapper.emitted('update:annotations'))[0][0].type()).to.equal('line');
+  });
+
+  it('edit a rectangle', () => {
+    const wrapper = mountAnnotationLayer({
+      propsData: { editable: true },
+    });
+    wrapper.setProps({ drawing: 'rectangle' });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('rectangle');
+
+    drag({ x: 0, y: 0 }, { x: 10, y: 15 });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal(null);
+
+    interact('mousemove', { x: 100, y: 100 });
+    interact('mousemove', { x: 5, y: 5 });
+    click({ x: 5, y: 5 });
+
+    const id = wrapper.vm.state[0].id();
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('edit');
+    expect(wrapper.emitted('update:editing')).to.eql([[id]]);
+
+    wrapper.setProps({ editing: id });
+    expect(wrapper.vm.activeAnnotation).to.equal(wrapper.vm.state[0]);
+  });
+
+  it('cancel drawing via props', () => {
+    const wrapper = mountAnnotationLayer();
+    wrapper.setProps({ drawing: 'point' });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('point');
+
+    wrapper.setProps({ drawing: false });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal(null);
+  });
+
+  it('add an annotation via props', () => {
+    const wrapper = mountAnnotationLayer();
+    const point = geojs.annotation.annotation('point');
+
+    wrapper.vm.annotations = [point];
+    expect(wrapper.vm.state).to.eql([point]);
+  });
+
+  it('remove an annotation via props', () => {
+    const wrapper = mountAnnotationLayer({
+      propsData: {
+        initialGeojson: {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 15],
+            },
+          }],
+        },
+      },
+    });
+
+    wrapper.vm.annotations = [];
+    expect(wrapper.vm.state).to.eql([]);
+  });
+
+  it('add and remove annotations via props', () => {
+    const wrapper = mountAnnotationLayer({
+      propsData: {
+        initialGeojson: {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 15],
+            },
+          }],
+        },
+      },
+    });
+    const point = geojs.annotation.annotation('point');
+
+    wrapper.vm.annotations = [point];
+    expect(wrapper.vm.state).to.eql([point]);
+  });
+
+  it('mounted without the correct parent', () => {
+    // errors thrown in vue are printed to the console in non-production mode
+    sinon.stub(console, 'error');
+    const func = () => {
+      mount(GeojsAnnotationLayer);
+    };
+
+    expect(func).to.throw(/Annotation layer must be a child of a GeojsMapViewport/);
+    console.error.restore(); // eslint-disable-line no-console
+  });
+});


### PR DESCRIPTION
The annotation layer currently provides the following:

* Contains a computed property to generate existing annotations as geojson.
* Toggles drawing mode for points, lines, rectangles, and polygons from props.
* Contains several props with `update` events that can be bound with the `.sync` modifier to simulate two way data binding.

There are also several initialization props that aren't reactive (for now):

* Initial annotations as geojson
* Whether annotations are editable
* Whether annotations are drawn with labels