### PR TITLE
Add a Geojs geojson layer

### DIFF
--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -10,12 +10,15 @@ full-screen-viewport
       :attribution='attribution',
       :opacity='opacity'
     )
+    geojs-geojson-layer(
+      :geojson='geojson',
+      :opacity='0.5'
+    )
     geojs-annotation-layer(
       :drawing.sync='drawing',
       :editing.sync='editing',
       :editable='true',
-      :annotations.sync='annotations',
-      :initialGeojson='geojson'
+      :annotations.sync='annotations'
     )
 
   side-panel(

--- a/src/components/geojs/GeojsGeojsonLayer.vue
+++ b/src/components/geojs/GeojsGeojsonLayer.vue
@@ -9,8 +9,7 @@ import { layerMixin } from './mixins';
 export default {
   mixins: [layerMixin],
   props: {
-    geojson: {
-      type: [Object, Array],
+    geojson: { // eslint-disable-line vue/require-prop-types
       required: true,
     },
     opacity: {
@@ -39,11 +38,13 @@ export default {
   },
   methods: {
     draw() {
-      this.$geojsLayer.clear();
-      this.$geojsReader.read(this.geojson, (features) => {
-        this.$features = features;
-        this.$geojsLayer.draw();
-      });
+      this.$geojsLayer.clear().draw();
+      if (this.geojson) {
+        this.$geojsReader.read(this.geojson, (features) => {
+          this.$features = features;
+          this.$geojsLayer.draw();
+        });
+      }
     },
   },
 };

--- a/src/components/geojs/GeojsGeojsonLayer.vue
+++ b/src/components/geojs/GeojsGeojsonLayer.vue
@@ -1,0 +1,50 @@
+<template lang="pug">
+// geojs geojson layer
+</template>
+
+<script>
+import bindWatchers from './bindWatchers';
+import { layerMixin } from './mixins';
+
+export default {
+  mixins: [layerMixin],
+  props: {
+    geojson: {
+      type: [Object, Array],
+      required: true,
+    },
+    opacity: {
+      type: Number,
+      default: 1,
+    },
+  },
+  watch: {
+    geojson: {
+      handler() {
+        this.draw();
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    this.$geojsLayer = this.$geojsMap.createLayer('feature', {
+      opacity: this.opacity,
+    });
+    this.$geojsReader = this.$geojs.jsonReader({
+      layer: this.$geojsLayer,
+    });
+    this.$features = [];
+    bindWatchers(this, this.$geojsLayer, ['opacity']);
+    this.draw();
+  },
+  methods: {
+    draw() {
+      this.$geojsLayer.clear();
+      this.$geojsReader.read(this.geojson, (features) => {
+        this.$features = features;
+        this.$geojsLayer.draw();
+      });
+    },
+  },
+};
+</script>

--- a/src/components/geojs/index.js
+++ b/src/components/geojs/index.js
@@ -1,4 +1,5 @@
 import GeojsAnnotationLayer from './GeojsAnnotationLayer';
+import GeojsGeojsonLayer from './GeojsGeojsonLayer';
 import GeojsHeatmapLayer from './GeojsHeatmapLayer';
 import GeojsMapViewport from './GeojsMapViewport';
 import GeojsTileLayer from './GeojsTileLayer';
@@ -7,6 +8,7 @@ import mixins from './mixins';
 
 export {
   GeojsAnnotationLayer,
+  GeojsGeojsonLayer,
   GeojsHeatmapLayer,
   GeojsMapViewport,
   GeojsTileLayer,

--- a/test/specs/GeojsGeojsonLayer.spec.js
+++ b/test/specs/GeojsGeojsonLayer.spec.js
@@ -41,6 +41,17 @@ describe('GeojsTileLayer.vue', () => {
     expect(layer.features()[0].data()).to.eql([geojson]);
   });
 
+  it('mount with null', () => {
+    const geojson = null;
+    const wrapper = mountLayer({
+      propsData: { geojson },
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.features()).to.eql([]);
+    expect(wrapper.vm.$features).to.eql([]);
+  });
+
   it('responds to data changes', () => {
     const geojson = {
       type: 'Feature',
@@ -58,5 +69,6 @@ describe('GeojsTileLayer.vue', () => {
     const layer = wrapper.vm.$geojsLayer;
     expect(layer.features().length).to.equal(1);
     expect(layer.features()[0].data()).to.eql([geojson]);
+    expect(wrapper.vm.$features.length).to.eql(1);
   });
 });

--- a/test/specs/GeojsGeojsonLayer.spec.js
+++ b/test/specs/GeojsGeojsonLayer.spec.js
@@ -1,0 +1,62 @@
+import geojs from 'geojs';
+import { mount } from '@vue/test-utils';
+
+import GeojsMapViewport from '@/components/geojs/GeojsMapViewport';
+import GeojsGeojsonLayer from '@/components/geojs/GeojsGeojsonLayer';
+
+describe('GeojsTileLayer.vue', () => {
+  let mapWrapper;
+  function mountLayer(options = {}) {
+    return mount(GeojsGeojsonLayer, {
+      testParent: mapWrapper.vm,
+      ...options,
+    });
+  }
+
+  beforeEach(() => {
+    geojs.util.mockVGLRenderer();
+    sinon.stub(console, 'warn');
+    mapWrapper = mount(GeojsMapViewport);
+  });
+  afterEach(() => {
+    console.warn.restore(); // eslint-disable-line no-console
+    mapWrapper.destroy();
+    geojs.util.restoreVGLRenderer();
+  });
+
+  it('mount with data', () => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [10, 15],
+      },
+    };
+    const wrapper = mountLayer({
+      propsData: { geojson },
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.features().length).to.equal(1);
+    expect(layer.features()[0].data()).to.eql([geojson]);
+  });
+
+  it('responds to data changes', () => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [10, 15],
+      },
+    };
+    const wrapper = mountLayer({
+      propsData: { geojson },
+    });
+
+    geojson.geometry.coordinates = [-10, 4];
+
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.features().length).to.equal(1);
+    expect(layer.features()[0].data()).to.eql([geojson]);
+  });
+});


### PR DESCRIPTION
This layer is similar to the annotation layer in that it is initialized
with a geojson object, but rendered features cannot be modified by the
layer itself.  The geojson prop provided to the layer is fully reactive
and will trigger a redraw for arbitrary changes to the geojson object
provided.

This component replaces all features on data changes; it is not designed
to be performant for large datasets.  Applications requiring frequent
redraw's and/or large numbers of features should modify the geojs
objects directly instead of relying on the built-in reactivity.