### PR TITLE
Add the ability to provide geojson styling

### DIFF
--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -11,8 +11,9 @@ full-screen-viewport
       :opacity='opacity'
     )
     geojs-geojson-layer(
+      :featureStyle='featureStyle',
       :geojson='geojson',
-      :opacity='0.5'
+      :opacity='1'
     )
     geojs-annotation-layer(
       :drawing.sync='drawing',
@@ -132,6 +133,16 @@ export default {
             coordinates: [-73.7569, 42.8495],
           },
         }],
+      },
+      featureStyle: {
+        point: {
+          fillOpacity: 1,
+          fillColor: 'steelblue',
+          strokeColor: 'black',
+          strokeWidth: 5,
+          strokeOpacity: 0.5,
+          radius: 15,
+        },
       },
     };
   },

--- a/src/components/geojs/GeojsGeojsonLayer.vue
+++ b/src/components/geojs/GeojsGeojsonLayer.vue
@@ -16,11 +16,27 @@ export default {
       type: Number,
       default: 1,
     },
+    featureStyle: {
+      type: Object,
+      default() {
+        return {
+          point: {},
+          line: {},
+          polygon: {},
+        };
+      },
+    },
   },
   watch: {
     geojson: {
       handler() {
-        this.draw();
+        this.updateData();
+      },
+      deep: true,
+    },
+    featureStyle: {
+      handler() {
+        this.updateStyle();
       },
       deep: true,
     },
@@ -34,17 +50,29 @@ export default {
     });
     this.$features = [];
     bindWatchers(this, this.$geojsLayer, ['opacity']);
-    this.draw();
+    this.updateData();
   },
   methods: {
     draw() {
+      this.$geojsLayer.draw();
+    },
+    updateData() {
       this.$geojsLayer.clear().draw();
       if (this.geojson) {
         this.$geojsReader.read(this.geojson, (features) => {
           this.$features = features;
-          this.$geojsLayer.draw();
+          this.updateStyle();
         });
       }
+    },
+    updateStyle() {
+      this.$features.forEach((feature) => {
+        const type = feature.featureType;
+        if (this.featureStyle[type]) {
+          feature.style(this.featureStyle[type]);
+        }
+      });
+      this.draw();
     },
   },
 };

--- a/test/specs/GeojsGeojsonLayer.spec.js
+++ b/test/specs/GeojsGeojsonLayer.spec.js
@@ -41,6 +41,48 @@ describe('GeojsTileLayer.vue', () => {
     expect(layer.features()[0].data()).to.eql([geojson]);
   });
 
+  it('mount with default feature style', () => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [10, 15],
+      },
+    };
+    const featureStyle = {};
+    const wrapper = mountLayer({
+      propsData: { geojson, featureStyle },
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.features().length).to.equal(1);
+  });
+
+  it('mount with feature style', () => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [10, 15],
+      },
+    };
+    const featureStyle = {
+      point: {
+        fillColor: 'red',
+        lineWidth: 5,
+      },
+      line: null,
+    };
+    const wrapper = mountLayer({
+      propsData: { geojson, featureStyle },
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.features().length).to.equal(1);
+    expect(layer.features()[0].style('fillColor')).to.equal('red');
+    expect(layer.features()[0].style('lineWidth')).to.equal(5);
+  });
+
   it('mount with null', () => {
     const geojson = null;
     const wrapper = mountLayer({
@@ -70,5 +112,29 @@ describe('GeojsTileLayer.vue', () => {
     expect(layer.features().length).to.equal(1);
     expect(layer.features()[0].data()).to.eql([geojson]);
     expect(wrapper.vm.$features.length).to.eql(1);
+  });
+
+  it('responds to feature style changes', () => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [10, 15],
+      },
+    };
+    const featureStyle = {
+      point: {
+        fillColor: 'red',
+        lineWidth: 5,
+      },
+    };
+    const wrapper = mountLayer({
+      propsData: { geojson, featureStyle },
+    });
+
+    featureStyle.point.fillColor = 'rgba(0,128,255,0.1)';
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.features().length).to.equal(1);
+    expect(layer.features()[0].style('fillColor')).to.equal('rgba(0,128,255,0.1)');
   });
 });


### PR DESCRIPTION
This adds a `featureStyle` prop to the geojson layer type.  Users can
provide an independent style for each of the raw geojson types (point,
line, and polygon).  The style object is passed directly to the
`feature.style` method, so anything supported by geojs can be used here.

Note: If a function is provided as a style property, then you may need
to manually call the `draw()` method on the layer component when it
needs to be rerendered.