### PR TITLE
Add a layer component to display arbitrary html

### DIFF
--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -21,6 +21,12 @@ full-screen-viewport
       :editable='true',
       :annotations.sync='annotations'
     )
+    geojs-widget-layer(
+      :position='widget.position',
+      :offset='widget.offset',
+      :size='widget.size'
+    )
+      v-btn(color='success') Clifton Park
 
   side-panel(
     :top='64',
@@ -143,6 +149,11 @@ export default {
           strokeOpacity: 0.5,
           radius: 15,
         },
+      },
+      widget: {
+        size: { width: 142.5, height: 48 },
+        position: { x: -73.7569, y: 42.8495 },
+        offset: { x: 0, y: -30 },
       },
     };
   },

--- a/src/components/geojs/GeojsWidgetLayer.vue
+++ b/src/components/geojs/GeojsWidgetLayer.vue
@@ -1,0 +1,80 @@
+<template lang="pug">
+.widget-content(:style='cssPosition')
+  slot
+</template>
+
+<style lang="stylus" scoped>
+.widget-content
+  position absolute
+  pointer-events none
+</style>
+
+<script>
+import { layerMixin } from './mixins';
+
+export default {
+  mixins: [layerMixin],
+  props: {
+    // element size in pixels
+    size: {
+      type: Object,
+      default() {
+        return { width: 0, height: 0 };
+      },
+    },
+    // offset in pixels
+    offset: {
+      type: Object,
+      default() {
+        return { x: 0, y: 0 };
+      },
+    },
+    // position of center in lat/lon
+    position: {
+      type: Object,
+      default() {
+        return { x: 0, y: 0 };
+      },
+    },
+  },
+  data() {
+    return {
+      center: { x: 0, y: 0 },
+    };
+  },
+  computed: {
+    cssPosition() {
+      return {
+        width: `${this.size.width}px`,
+        height: `${this.size.height}px`,
+        left: `${(this.center.x + this.offset.x) - (this.size.width / 2)}px`,
+        top: `${(this.center.y + this.offset.y) - (this.size.height / 2)}px`,
+      };
+    },
+  },
+  watch: {
+    position: {
+      handler() {
+        this.reposition();
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    this.$geojsLayer = this.$geojsMap.createLayer('feature', {
+      renderer: null,
+    });
+    this.$geojsLayer.canvas().css({ overflow: 'hidden' });
+    this.$geojsLayer.canvas().append(this.$el);
+    this.$geojsMap.geoOn(this.$geojs.event.pan, this.reposition);
+    this.reposition();
+  },
+  methods: {
+    reposition() {
+      this.center = this.$geojsMap.gcsToDisplay(this.position);
+      this.center.x += this.offset.x;
+      this.center.y += this.offset.y;
+    },
+  },
+};
+</script>

--- a/src/components/geojs/index.js
+++ b/src/components/geojs/index.js
@@ -3,6 +3,7 @@ import GeojsGeojsonLayer from './GeojsGeojsonLayer';
 import GeojsHeatmapLayer from './GeojsHeatmapLayer';
 import GeojsMapViewport from './GeojsMapViewport';
 import GeojsTileLayer from './GeojsTileLayer';
+import GeojsWidgetLayer from './GeojsWidgetLayer';
 import bindWatchers from './bindWatchers';
 import mixins from './mixins';
 
@@ -12,6 +13,7 @@ export {
   GeojsHeatmapLayer,
   GeojsMapViewport,
   GeojsTileLayer,
+  GeojsWidgetLayer,
   bindWatchers,
   mixins,
 };

--- a/test/specs/GeojsWidgetLayer.spec.js
+++ b/test/specs/GeojsWidgetLayer.spec.js
@@ -1,0 +1,105 @@
+import { mount } from '@vue/test-utils';
+
+import GeojsMapViewport from '@/components/geojs/GeojsMapViewport';
+import GeojsWidgetLayer from '@/components/geojs/GeojsWidgetLayer';
+
+const TestComponent = {
+  functional: true,
+  render(createElement) {
+    return createElement('div', 'Test component');
+  },
+};
+
+describe('GeojsWidgetLayer.vue', () => {
+  let displayPosition = { x: 10, y: 20 };
+  let mapWrapper;
+  let gcsToDisplay;
+
+  function mountLayer(options = {}) {
+    return mount(GeojsWidgetLayer, {
+      testParent: mapWrapper.vm,
+      slots: {
+        default: TestComponent,
+      },
+      ...options,
+    });
+  }
+
+  beforeEach(() => {
+    sinon.stub(console, 'warn');
+    mapWrapper = mount(GeojsMapViewport);
+    gcsToDisplay = sinon.stub(mapWrapper.vm.$geojsMap, 'gcsToDisplay').callsFake(() => displayPosition);
+  });
+  afterEach(() => {
+    console.warn.restore(); // eslint-disable-line no-console
+    gcsToDisplay.restore();
+    mapWrapper.destroy();
+  });
+
+  it('mounted with default slot', () => {
+    const wrapper = mountLayer();
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.canvas().text()).to.equal('Test component');
+  });
+
+  it('mounted with correct size', () => {
+    const wrapper = mountLayer({
+      propsData: {
+        size: { width: 300, height: 30 },
+      },
+    });
+    expect(wrapper.find('.widget-content').element.style.width).to.equal('300px');
+    expect(wrapper.find('.widget-content').element.style.height).to.equal('30px');
+  });
+  it('mounted with correct position', () => {
+    const position = { x: 0, y: 0 };
+    const wrapper = mountLayer({
+      propsData: {
+        size: { width: 100, height: 50 },
+        position,
+        offset: { x: 0, y: 0 },
+      },
+    });
+
+    expect(gcsToDisplay).to.have.been.calledOnce;
+    expect(gcsToDisplay).to.have.been.calledWith(position);
+    expect(wrapper.vm.cssPosition.left).to.equal(`${displayPosition.x - (100 / 2)}px`);
+    expect(wrapper.vm.cssPosition.top).to.equal(`${displayPosition.y - (50 / 2)}px`);
+  });
+  it('mounted with correct position and offset', () => {
+    const position = { x: 0, y: 0 };
+    const wrapper = mountLayer({
+      propsData: {
+        size: { width: 100, height: 50 },
+        position,
+        offset: { x: 50, y: -10 },
+      },
+    });
+
+    expect(gcsToDisplay).to.have.been.calledOnce;
+    expect(gcsToDisplay).to.have.been.calledWith(position);
+    expect(wrapper.vm.cssPosition.left).to.equal(`${(displayPosition.x + 50) - (100 / 2)}px`);
+    expect(wrapper.vm.cssPosition.top).to.equal(`${(displayPosition.y - 10) - (50 / 2)}px`);
+  });
+  it('responds to position changes', () => {
+    const position = { x: 0, y: 0 };
+    const wrapper = mountLayer({
+      propsData: {
+        size: { width: 100, height: 50 },
+        position,
+        offset: { x: 50, y: -10 },
+      },
+    });
+
+    expect(gcsToDisplay).to.have.been.calledOnce;
+    expect(gcsToDisplay).to.have.been.calledWith(position);
+
+    displayPosition = { x: 5, y: -10 };
+    position.x = 5;
+
+    expect(gcsToDisplay).to.have.been.calledTwice;
+    expect(gcsToDisplay).to.have.been.calledWith(position);
+    expect(wrapper.vm.cssPosition.left).to.equal(`${(displayPosition.x + 50) - (100 / 2)}px`);
+    expect(wrapper.vm.cssPosition.top).to.equal(`${(displayPosition.y - 10) - (50 / 2)}px`);
+  });
+});


### PR DESCRIPTION
This adds a new `GeojsWidgetLayer` component for displaying arbitrary
content inside an element that pans with the map.  The logic in this
layer is primarily dedicated to setting the `left` and `top` css
properties of the widget parent when the map pans.

This default slot is appended to the layer's canvas on mount.  This
could cause problems when using with `v-if` directives depending on how
vue works.  I can make adjustments if there is ever a use case for this
behavior.

Props:
  * position: The lat/lon position to center the element on
  * size: The size of the component used to center the element correctly
  * offset: Shifts the anchor point by the given offset in pixels

Example use case: Adding a text label to the right of -100 longitude 40
latitude.

```pug
geojs-widget-layer(
  :position='{x: -100, y: 40}',
  :size='{width: 140, height: 50}',
  :offset='{x: 70, y: 0}'  // anchor to the left center
)
  p Label
```