### PR TITLE
feat(geojs): add zIndex and opacity props to all layers

### DIFF
--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -8,23 +8,27 @@ full-screen-viewport
       v-if='baseLayer',
       :url='url',
       :attribution='attribution',
-      :opacity='opacity'
+      :opacity='opacity',
+      :zIndex='0'
     )
     geojs-geojson-layer(
       :featureStyle='featureStyle',
       :geojson='geojson',
-      :opacity='1'
+      :opacity='1',
+      :zIndex='1'
     )
     geojs-annotation-layer(
       :drawing.sync='drawing',
       :editing.sync='editing',
       :editable='true',
-      :annotations.sync='annotations'
+      :annotations.sync='annotations',
+      :zIndex='2'
     )
     geojs-widget-layer(
       :position='widget.position',
       :offset='widget.offset',
-      :size='widget.size'
+      :size='widget.size',
+      :zIndex='3'
     )
       v-btn(color='success') Clifton Park
 

--- a/src/bindWatchers.js
+++ b/src/bindWatchers.js
@@ -1,11 +1,12 @@
-import bind from 'lodash-es/bind';
-
 export default function bindWatchers(vueComponent, geojsObject, props) {
+  const unwatch = vueComponent.$unwatch;
   props.forEach((prop) => {
-    vueComponent.$watch(prop, bind(geojsObject[prop], geojsObject));
-    vueComponent.$watch(prop, (value) => {
+    if (unwatch.has(prop)) {
+      unwatch.get(prop)();
+    }
+    unwatch.set(prop, vueComponent.$watch(prop, (value) => {
       geojsObject[prop].call(geojsObject, value);
       geojsObject.draw();
-    });
+    }));
   });
 }

--- a/src/components/SidePanel.vue
+++ b/src/components/SidePanel.vue
@@ -41,6 +41,7 @@ v-navigation-drawer.drawer-with-action-buttons(
 <style lang="stylus" scoped>
 .navigation-drawer
   overflow visible
+  z-index 100
 
 .action-buttons
   position fixed

--- a/src/components/geojs/GeojsAnnotationLayer.vue
+++ b/src/components/geojs/GeojsAnnotationLayer.vue
@@ -84,7 +84,7 @@ export default {
     },
   },
   mounted() {
-    this.$geojsLayer = this.$geojsMap.createLayer('annotation', {
+    this.createLayer('annotation', {
       showLabels: this.labels,
       clickToEdit: this.editable,
     });

--- a/src/components/geojs/GeojsGeojsonLayer.vue
+++ b/src/components/geojs/GeojsGeojsonLayer.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script>
-import bindWatchers from '../../bindWatchers';
 import layerMixin from '../../mixins/geojsLayer';
 
 export default {
@@ -11,10 +10,6 @@ export default {
   props: {
     geojson: { // eslint-disable-line vue/require-prop-types
       required: true,
-    },
-    opacity: {
-      type: Number,
-      default: 1,
     },
     featureStyle: {
       type: Object,
@@ -42,14 +37,13 @@ export default {
     },
   },
   mounted() {
-    this.$geojsLayer = this.$geojsMap.createLayer('feature', {
+    this.createLayer('feature', {
       opacity: this.opacity,
     });
     this.$geojsReader = this.$geojs.jsonReader({
       layer: this.$geojsLayer,
     });
     this.$features = [];
-    bindWatchers(this, this.$geojsLayer, ['opacity']);
     this.updateData();
   },
   methods: {

--- a/src/components/geojs/GeojsHeatmapLayer.vue
+++ b/src/components/geojs/GeojsHeatmapLayer.vue
@@ -22,10 +22,6 @@ export default {
       type: Array,
       required: true,
     },
-    opacity: {
-      type: Number,
-      default: 1,
-    },
     intensity: {
       type: Function,
       default: constant(1),
@@ -74,11 +70,9 @@ export default {
     },
   },
   mounted() {
-    this.$geojsLayer = this.$geojsMap.createLayer('feature', {
-      opacity: this.opacity,
+    this.createLayer('feature', {
       features: ['heatmap'],
     });
-    bindWatchers(this, this.$geojsLayer, ['opacity']);
 
     this.$geojsFeature = this.$geojsLayer.createFeature('heatmap', {
       intensity: this.intensity,

--- a/src/components/geojs/GeojsTileLayer.vue
+++ b/src/components/geojs/GeojsTileLayer.vue
@@ -17,28 +17,18 @@ export default {
       type: String,
       default: '',
     },
-    opacity: {
-      type: Number,
-      default: 1,
-      validator(value) {
-        return value <= 1 && value >= 0;
-      },
-    },
     wrapX: {
       type: Boolean,
       default: true,
     },
   },
   mounted() {
-    this.$geojsLayer = this.$geojsMap.createLayer('osm', {
+    this.createLayer('osm', {
       url: this.url,
       attribution: this.attribution,
-      opacity: this.opacity,
       wrapX: this.wrapX,
     });
-    bindWatchers(this, this.$geojsLayer, [
-      'url', 'attribution', 'opacity',
-    ]);
+    bindWatchers(this, this.$geojsLayer, ['url', 'attribution']);
   },
 };
 </script>

--- a/src/components/geojs/GeojsWidgetLayer.vue
+++ b/src/components/geojs/GeojsWidgetLayer.vue
@@ -61,7 +61,7 @@ export default {
     },
   },
   mounted() {
-    this.$geojsLayer = this.$geojsMap.createLayer('feature', {
+    this.createLayer('feature', {
       renderer: null,
     });
     this.$geojsLayer.canvas().css({ overflow: 'hidden' });

--- a/src/mixins/geojsLayer.js
+++ b/src/mixins/geojsLayer.js
@@ -1,8 +1,27 @@
+import bindWatchers from '../bindWatchers';
+
 const layerMixin = {
+  props: {
+    zIndex: {
+      type: Number,
+      default: 0,
+    },
+    opacity: {
+      type: Number,
+      default: 1,
+    },
+  },
   beforeDestroy() {
+    this.$unwatch.forEach((unwatch) => {
+      unwatch();
+    });
     this.$geojsMap.deleteLayer(this.$geojsLayer);
+    delete this.$unwatch;
     delete this.$geojsLayer;
     delete this.$geojsMap;
+  },
+  created() {
+    this.$unwatch = new Map();
   },
   mounted() {
     // This is in place purely for testing because there is no way
@@ -15,6 +34,24 @@ const layerMixin = {
     }
     this.$geojsMap = this.$parent.$geojsMap;
     this.$geojs = this.$parent.$geojs;
+  },
+  methods: {
+    createLayer(type, options) {
+      this.$geojsLayer = this.$geojsMap.createLayer(type, {
+        opacity: this.opacity,
+        zIndex: this.zIndex,
+        ...options,
+      });
+      bindWatchers(this, this.$geojsLayer, ['zIndex', 'opacity']);
+    },
+    removeLayer() {
+      this.$unwatch.forEach((unwatch) => {
+        unwatch();
+      });
+      this.$unwatch.clear();
+      this.$geojsMap.deleteLayer(this.$geojsLayer);
+      delete this.$geojsLayer;
+    },
   },
 };
 

--- a/test/specs/GeojsLayerMixin.spec.js
+++ b/test/specs/GeojsLayerMixin.spec.js
@@ -1,3 +1,4 @@
+import bindWatchers from '@/bindWatchers';
 import layerMixin from '@/mixins/geojsLayer';
 
 function mount(parent) {
@@ -17,6 +18,48 @@ describe('Geojs layer mixin', () => {
     expect(() => mount({})).to.throw(/A layer must be a child of a GeojsMapViewport/);
   });
 
+  it('unbinds old watchers', () => {
+    const prop1Stub = sinon.stub();
+    const component = {
+      $watch: sinon.stub().returns(() => sinon.stub()),
+      $unwatch: new Map([['prop1', prop1Stub]]),
+    };
+    const layer = {
+      prop1: sinon.stub(),
+      prop2: sinon.stub(),
+    };
+    bindWatchers(component, layer, ['prop1', 'prop2']);
+    expect([...component.$unwatch.keys()]).to.have.members(['prop1', 'prop2']);
+    prop1Stub.should.have.been.calledOnce;
+  });
+
+  it('cleans up on removeLayer', () => {
+    let called;
+    const layer = {};
+    const deleteLayer = function deleteLayer(arg) {
+      called = true;
+      expect(arg).to.equal(layer);
+    };
+    const unwatch1 = sinon.stub();
+    const unwatch2 = sinon.stub();
+
+    const context = {
+      $geojsMap: {
+        deleteLayer,
+      },
+      $geojsLayer: layer,
+      $unwatch: new Map([
+        ['prop1', unwatch1],
+        ['prop2', unwatch2],
+      ]),
+    };
+    layerMixin.methods.removeLayer.call(context);
+
+    expect(called).to.equal(true);
+    unwatch1.should.have.been.calledOnce;
+    unwatch2.should.have.been.calledOnce;
+  });
+
   it('destroys on exit', () => {
     let called;
     const layer = {};
@@ -24,15 +67,24 @@ describe('Geojs layer mixin', () => {
       called = true;
       expect(arg).to.equal(layer);
     };
+    const unwatch1 = sinon.stub();
+    const unwatch2 = sinon.stub();
+
     const context = {
       $geojsMap: {
         deleteLayer,
       },
       $geojsLayer: layer,
+      $unwatch: new Map([
+        ['prop1', unwatch1],
+        ['prop2', unwatch2],
+      ]),
     };
     layerMixin.beforeDestroy.call(context);
 
     expect(context).to.be.empty;
     expect(called).to.equal(true);
+    unwatch1.should.have.been.calledOnce;
+    unwatch2.should.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
This modifies the geojsLayer mixin to provide reactive zIndex and
opacity props to all layer types.  The opacity prop is now deduplicated
across all layers that previously supported the feature.

The zIndex prop is intend to provide a hook for developers to ensure the
layer order is consistent.  The previous behavior was that the z order
was determined by the order in which the layers were added to the map.
This causes issues for cases when the layer is added asynchronously into
the virtual DOM.