### PR TITLE
Listen to nested changes in heatmap data

### DIFF
--- a/examples/layout/src/HeatmapView.vue
+++ b/examples/layout/src/HeatmapView.vue
@@ -6,7 +6,8 @@ full-screen-viewport
   )
     geojs-tile-layer(
       :url='url',
-      :attribution='attribution'
+      :attribution='attribution',
+      :zIndex='0'
     )
     geojs-heatmap-layer(
       :data='data',
@@ -14,7 +15,8 @@ full-screen-viewport
       :binned='binned',
       :maxIntensity='maxIntensity',
       :minIntensity='minIntensity',
-      :updateDelay='updateDelay'
+      :updateDelay='updateDelay',
+      :zIndex='1'
     )
 
   side-panel(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16121,9 +16121,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.0.18.tgz",
-      "integrity": "sha512-adOZaSCgoeGgyL3bgm0bpAfbUJWQ9WVD6CBpJriQJ6JUMaKNoEvKnuhY5LGRlR209QOx4LB8e6HBlKtGwbFtIA=="
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.0.14.tgz",
+      "integrity": "sha512-bZrf1ZkyeOoZz4APt6APxfBAvz1UPnvY3ZrAjYg/PDmI5qnn7535oJLnWLoSR+yFPcDaqCIc+UqAdzi4rCZ52Q=="
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "geojs": "^0.16.0",
     "lodash-es": "^4.17.10",
     "vue": "^2.5.16",
-    "vuetify": "^1.0.18"
+    "vuetify": "1.0.14"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.2.0",

--- a/src/bindWatchers.js
+++ b/src/bindWatchers.js
@@ -7,6 +7,6 @@ export default function bindWatchers(vueComponent, geojsObject, props) {
     unwatch.set(prop, vueComponent.$watch(prop, (value) => {
       geojsObject[prop].call(geojsObject, value);
       geojsObject.draw();
-    }));
+    }, { deep: true }));
   });
 }

--- a/src/components/geojs/GeojsHeatmapLayer.vue
+++ b/src/components/geojs/GeojsHeatmapLayer.vue
@@ -62,11 +62,11 @@ export default {
     },
   },
   watch: {
-    data() {
-      this.$geojsFeature.data(this.data).draw();
-    },
-    layerStyle() {
-      this.$geojsFeature.style(this.layerStyle).draw();
+    layerStyle: {
+      handler() {
+        this.$geojsFeature.style(this.layerStyle).draw();
+      },
+      deep: true,
     },
   },
   mounted() {
@@ -81,14 +81,14 @@ export default {
       minIntensity: this.minIntensity,
       updateDelay: this.updateDelay,
       binned: this.binned,
-      style: this.style,
+      style: this.layerStyle,
     });
 
     if (this.data) {
       this.$geojsFeature.data(this.data).draw();
     }
     bindWatchers(this, this.$geojsFeature, [
-      'intensity', 'position', 'maxIntensity', 'minIntensity', 'updateDelay', 'binned',
+      'intensity', 'position', 'maxIntensity', 'minIntensity', 'updateDelay', 'binned', 'data',
     ]);
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8849,9 +8849,9 @@ vue@^2.5.16:
   version "2.5.16"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
 
-vuetify@^1.0.18:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.0.18.tgz#56289ba7c6e5eee3d4ee4dacd5e7dded4aee4c08"
+vuetify@1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.0.14.tgz#ab1f0e702383f66f9d320fd8e1cd2d63e7871e0b"
 
 watchpack@^1.4.0:
   version "1.6.0"


### PR DESCRIPTION
This fixes a few small issues in the heatmap layer and example.
1. Use the "deep" flag when watching props to respond to changes in nested data.
2. Update the heatmap example to use zIndex.
3. Downgrade Vuetify to version 1.0.14 to fix resize bug in geojs's heatmap feature.  https://github.com/OpenGeoscience/geojs/issues/826