### PR TITLE
Do not trigger state changes for empty annotations

### DIFF
--- a/src/components/geojs/GeojsAnnotationLayer.vue
+++ b/src/components/geojs/GeojsAnnotationLayer.vue
@@ -4,6 +4,7 @@
 
 <script>
 import bind from 'lodash-es/bind';
+import filter from 'lodash-es/filter';
 import forEach from 'lodash-es/forEach';
 import indexOf from 'lodash-es/indexOf';
 import differenceBy from 'lodash-es/differenceBy';
@@ -71,10 +72,15 @@ export default {
       this.$emit('update:annotations', this.state);
     },
     annotations() {
-      const toRemove = differenceBy(
+      /*
+       * Geojs adds an annotation with no features when draw mode is triggered.
+       * We leave those annotations out of the local state and prevent the view
+       * from pruning them by filtering them out here.
+       */
+      const toRemove = filter(differenceBy(
         this.$geojsLayer.annotations(), this.annotations,
         annotation => annotation.id(),
-      );
+      ), annotation => annotation.features().length);
       const toAdd = differenceBy(
         this.annotations, this.$geojsLayer.annotations(),
         annotation => annotation.id(),
@@ -120,7 +126,10 @@ export default {
       }
     },
     resetAnnotationState() {
-      this.state = this.$geojsLayer.annotations();
+      this.state = filter(
+        this.$geojsLayer.annotations(),
+        annotation => annotation.features().length,
+      );
     },
   },
 };

--- a/test/specs/GeojsAnnotationLayer.spec.js
+++ b/test/specs/GeojsAnnotationLayer.spec.js
@@ -162,6 +162,7 @@ describe('GeojsAnnotationLayer.vue', () => {
   it('add an annotation via props', () => {
     const wrapper = mountAnnotationLayer();
     const point = geojs.annotation.annotation('point');
+    sinon.stub(point, 'features').returns([{}]);
 
     wrapper.vm.annotations = [point];
     expect(wrapper.vm.state).to.eql([point]);
@@ -203,8 +204,18 @@ describe('GeojsAnnotationLayer.vue', () => {
       },
     });
     const point = geojs.annotation.annotation('point');
+    sinon.stub(point, 'features').returns([{}]);
 
     wrapper.vm.annotations = [point];
     expect(wrapper.vm.state).to.eql([point]);
+  });
+
+  it('do not trigger state changes for empty annotations', () => {
+    const wrapper = mount(GeojsAnnotationLayer, {
+      testParent: mapWrapper.vm,
+    });
+    wrapper.setProps({ drawing: 'point' });
+    expect(wrapper.vm.$geojsLayer.mode()).to.equal('point');
+    expect(wrapper.vm.state).to.eql([]);
   });
 });


### PR DESCRIPTION
When draw mode is initialized geojs adds an annotation with no features
to the state.  This isn't usually what the watcher of the annotations
prop will be interested in.  Instead, this filters out all annotations
with no features from the exposed state on the Vue component.