### PR TITLE
Remove z-index from the SidePanel

### DIFF
--- a/src/components/SidePanel.vue
+++ b/src/components/SidePanel.vue
@@ -41,7 +41,6 @@ v-navigation-drawer.drawer-with-action-buttons(
 <style lang="stylus" scoped>
 .drawer-with-action-buttons
   overflow visible
-  z-index 100
   padding-bottom 0
 
 .action-buttons


### PR DESCRIPTION
I thought there was a reason I added this originally, but I can't find anything that breaks.

Fixes #41