### PR TITLE
chore(geojs): accept geojson position arrays as coordinates

### DIFF
--- a/examples/layout/src/HeatmapView.vue
+++ b/examples/layout/src/HeatmapView.vue
@@ -11,7 +11,6 @@ full-screen-viewport
     )
     geojs-heatmap-layer(
       :data='data',
-      :position='position',
       :binned='binned',
       :maxIntensity='maxIntensity',
       :minIntensity='minIntensity',
@@ -79,12 +78,6 @@ export default {
         expanded: true,
       },
       data: [],
-      position(d) {
-        return {
-          x: d[2],
-          y: d[1],
-        };
-      },
       binOptions: [{
         text: 'auto',
         value: 'auto',
@@ -112,7 +105,7 @@ export default {
         rows.splice(0, 1);
         this.data = rows.map((r) => {
           const fields = r.split(',');
-          return [fields[12], fields[24], fields[25]].map(parseFloat);
+          return [fields[25], fields[24]].map(parseFloat);
         });
       });
   },

--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -156,8 +156,8 @@ export default {
       },
       widget: {
         size: { width: 142.5, height: 48 },
-        position: { x: -73.7569, y: 42.8495 },
-        offset: { x: 0, y: -30 },
+        position: [-73.7569, 42.8495],
+        offset: [0, -30],
       },
     };
   },

--- a/src/bindWatchers.js
+++ b/src/bindWatchers.js
@@ -1,11 +1,41 @@
+import forEach from 'lodash-es/forEach';
+import isArray from 'lodash-es/isArray';
+import mapKeys from 'lodash-es/mapKeys';
+
+/**
+ * If the argument is an array, transform it into an object
+ * with keys equal to the value of the element in the array.
+ *
+ * [ 'a', 'b' ] -> { a: 'a', b: 'b' }
+ */
+function arrayToObject(arg) {
+  if (!isArray(arg)) {
+    return arg;
+  }
+  return mapKeys(arg);
+}
+
+/**
+ * Bind a watcher to a vue component that automatically calls a method
+ * on a geojs object when the prop changes.  The props argument can
+ * either be an array or an object with string values.
+ *
+ * For an object, it is a mapping from the component prop name to the geojs
+ * function to call, e.g. for `props = {'myPosition', 'position'}` will
+ * call the geojs method `position` whenever the component prop `myPosition`
+ * changes.
+ *
+ * For an array, the property name and geojs method name are assumed to
+ * be the same.
+ */
 export default function bindWatchers(vueComponent, geojsObject, props) {
   const unwatch = vueComponent.$unwatch;
-  props.forEach((prop) => {
+  forEach(arrayToObject(props), (geojsMethod, prop) => {
     if (unwatch.has(prop)) {
       unwatch.get(prop)();
     }
     unwatch.set(prop, vueComponent.$watch(prop, (value) => {
-      geojsObject[prop].call(geojsObject, value);
+      geojsObject[geojsMethod].call(geojsObject, value);
       geojsObject.draw();
     }, { deep: true }));
   });

--- a/src/components/geojs/GeojsHeatmapLayer.vue
+++ b/src/components/geojs/GeojsHeatmapLayer.vue
@@ -7,9 +7,11 @@ import constant from 'lodash-es/constant';
 import identity from 'lodash-es/identity';
 import isFinite from 'lodash-es/isFinite';
 import isString from 'lodash-es/isString';
+import compose from 'lodash-es/flowRight';
 
 import bindWatchers from '../../bindWatchers';
 import layerMixin from '../../mixins/geojsLayer';
+import { normalizePoint } from './utils';
 
 function intensityValidator(value) {
   return value === null || isFinite(value);
@@ -61,6 +63,11 @@ export default {
       },
     },
   },
+  computed: {
+    wrappedPosition() {
+      return compose([normalizePoint, this.position]);
+    },
+  },
   watch: {
     layerStyle: {
       handler() {
@@ -76,7 +83,7 @@ export default {
 
     this.$geojsFeature = this.$geojsLayer.createFeature('heatmap', {
       intensity: this.intensity,
-      position: this.position,
+      position: this.wrappedPosition,
       maxIntensity: this.maxIntensity,
       minIntensity: this.minIntensity,
       updateDelay: this.updateDelay,
@@ -88,8 +95,9 @@ export default {
       this.$geojsFeature.data(this.data).draw();
     }
     bindWatchers(this, this.$geojsFeature, [
-      'intensity', 'position', 'maxIntensity', 'minIntensity', 'updateDelay', 'binned', 'data',
+      'intensity', 'maxIntensity', 'minIntensity', 'updateDelay', 'binned', 'data',
     ]);
+    bindWatchers(this, this.$geojsFeature, { wrappedPosition: 'position' });
   },
 };
 </script>

--- a/src/components/geojs/GeojsWidgetLayer.vue
+++ b/src/components/geojs/GeojsWidgetLayer.vue
@@ -11,6 +11,7 @@
 
 <script>
 import layerMixin from '../../mixins/geojsLayer';
+import { normalizePoint } from './utils';
 
 export default {
   mixins: [layerMixin],
@@ -24,16 +25,16 @@ export default {
     },
     // offset in pixels
     offset: {
-      type: Object,
+      type: [Object, Array],
       default() {
-        return { x: 0, y: 0 };
+        return [0, 0];
       },
     },
     // position of center in lat/lon
     position: {
-      type: Object,
+      type: [Object, Array],
       default() {
-        return { x: 0, y: 0 };
+        return [0, 0];
       },
     },
   },
@@ -44,11 +45,13 @@ export default {
   },
   computed: {
     cssPosition() {
+      const center = normalizePoint(this.center);
+      const offset = normalizePoint(this.offset);
       return {
         width: `${this.size.width}px`,
         height: `${this.size.height}px`,
-        left: `${(this.center.x + this.offset.x) - (this.size.width / 2)}px`,
-        top: `${(this.center.y + this.offset.y) - (this.size.height / 2)}px`,
+        left: `${(center.x + offset.x) - (this.size.width / 2)}px`,
+        top: `${(center.y + offset.y) - (this.size.height / 2)}px`,
       };
     },
   },
@@ -71,7 +74,7 @@ export default {
   },
   methods: {
     reposition() {
-      this.center = this.$geojsMap.gcsToDisplay(this.position);
+      this.center = this.$geojsMap.gcsToDisplay(normalizePoint(this.position));
       this.center.x += this.offset.x;
       this.center.y += this.offset.y;
     },

--- a/src/components/geojs/index.js
+++ b/src/components/geojs/index.js
@@ -4,6 +4,7 @@ import GeojsHeatmapLayer from './GeojsHeatmapLayer';
 import GeojsMapViewport from './GeojsMapViewport';
 import GeojsTileLayer from './GeojsTileLayer';
 import GeojsWidgetLayer from './GeojsWidgetLayer';
+import * as utils from './utils';
 
 export {
   GeojsAnnotationLayer,
@@ -12,4 +13,5 @@ export {
   GeojsMapViewport,
   GeojsTileLayer,
   GeojsWidgetLayer,
+  utils,
 };

--- a/src/components/geojs/utils/index.js
+++ b/src/components/geojs/utils/index.js
@@ -1,0 +1,3 @@
+import normalizePoint from './normalizePoint';
+
+export { normalizePoint }; // eslint-disable-line import/prefer-default-export

--- a/src/components/geojs/utils/normalizePoint.js
+++ b/src/components/geojs/utils/normalizePoint.js
@@ -1,0 +1,8 @@
+import isArray from 'lodash-es/isArray';
+
+export default function normalizePoint(pt) {
+  if (isArray(pt)) {
+    return { x: pt[0], y: pt[1] };
+  }
+  return pt;
+}

--- a/test/specs/GeojsHeatmapLayer.spec.js
+++ b/test/specs/GeojsHeatmapLayer.spec.js
@@ -58,6 +58,11 @@ describe('GeojsTileLayer.vue', () => {
     expect(wrapper.vm.$geojsFeature.data()).to.eql(data);
   });
 
+  it('wrapped position getter', () => {
+    const wrapper = mountLayer();
+    expect(wrapper.vm.wrappedPosition([1, 2])).to.eql({ x: 1, y: 2 });
+  });
+
   it('data reactivity', () => {
     const data = [{ x: 1, y: 2 }];
     const wrapper = mountLayer();

--- a/test/specs/GeojsWidgetLayer.spec.js
+++ b/test/specs/GeojsWidgetLayer.spec.js
@@ -78,6 +78,16 @@ describe('GeojsWidgetLayer.vue', () => {
     expect(wrapper.vm.cssPosition.left).to.equal(`${(displayPosition.x + 50) - (100 / 2)}px`);
     expect(wrapper.vm.cssPosition.top).to.equal(`${(displayPosition.y - 10) - (50 / 2)}px`);
   });
+  it('mounted with a geojson position', () => {
+    mountLayer({
+      propsData: {
+        position: [10, 5],
+      },
+    });
+
+    expect(gcsToDisplay).to.have.been.calledOnce;
+    expect(gcsToDisplay).to.have.been.calledWith({ x: 10, y: 5 });
+  });
   it('responds to position changes', () => {
     const position = { x: 0, y: 0 };
     const wrapper = mountLayer({


### PR DESCRIPTION
In places where geojs expects point objects, i.e.
```{ x: 0, y: 0 }`)```
we now also accept Geojson position arrays (longitude, latitude) for more seamless integration with other geospatial tools.

Fixes #40