### PR TITLE
Only trigger a map resize when the canvas size changes

### DIFF
--- a/src/components/geojs/GeojsMapViewport.vue
+++ b/src/components/geojs/GeojsMapViewport.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.geojs-map
+.geojs-map(v-resize='onResize')
   slot(v-if='ready')
 </template>
 
@@ -66,6 +66,7 @@ export default {
       zoom: this.zoom,
       center: this.viewport.center,
       rotation: this.viewport.rotation,
+      autoResize: false,
     });
     this.$geojsMap.geoOn(geo.event.pan, () => {
       this.emitViewportEvents();
@@ -98,6 +99,17 @@ export default {
         zoom: this.$geojsMap.zoom(),
         rotation: this.$geojsMap.rotation(),
       });
+    },
+    onResize() {
+      if (!this.$geojsMap) {
+        return;
+      }
+
+      const size = this.$el.getBoundingClientRect();
+      const mapSize = this.$geojsMap.size();
+      if (size.width !== mapSize.width || size.height !== mapSize.height) {
+        this.$geojsMap.size(size);
+      }
     },
   },
 };

--- a/test/specs/GeojsMapViewport.spec.js
+++ b/test/specs/GeojsMapViewport.spec.js
@@ -119,6 +119,29 @@ describe('GeojsMapViewport.vue', () => {
     expect(wrapper.emitted().click).eql([[[-15, 10]]]);
   });
 
+  it('respond to resize events', () => {
+    const wrapper = mount(GeojsMapViewport, { attachToDocument: true });
+    const spy = sinon.spy(wrapper.vm.$geojsMap, 'size');
+    wrapper.vm.$el.style.width = '200px';
+    wrapper.vm.$el.style.height = '100px';
+
+    // collect the baseline call count after setting the initial size
+    window.dispatchEvent(new Event('resize'));
+    let calls = spy.callCount;
+
+    // should only call once when keeping the size the same
+    window.dispatchEvent(new Event('resize'));
+    calls += 1;
+    spy.should.have.callCount(calls);
+
+    // should call twice with a new size
+    wrapper.vm.$el.style.width = '150px';
+    wrapper.vm.$el.style.height = '50px';
+    window.dispatchEvent(new Event('resize'));
+    calls += 2;
+    spy.should.have.callCount(calls);
+  });
+
   it('map exits on component destroy', () => {
     const wrapper = mount(GeojsMapViewport);
     const spy = sinon.spy(wrapper.vm.$geojsMap, 'exit');


### PR DESCRIPTION
This issue was caused by the Vuetify update.  It is an interaction
between bugs in vuetify and geojs, both of which have fixes in the
pipeline, but are not released.  This gets around the issue by ignoring
the spurious resize events.

Fixes #51