### PR TITLE
Remove the size prop from GeojsWidgetLayer

### DIFF
--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -155,7 +155,6 @@ export default {
         },
       },
       widget: {
-        size: { width: 142.5, height: 48 },
         position: [-73.7569, 42.8495],
         offset: [0, -30],
       },

--- a/src/components/geojs/GeojsWidgetLayer.vue
+++ b/src/components/geojs/GeojsWidgetLayer.vue
@@ -16,13 +16,6 @@ import { normalizePoint } from './utils';
 export default {
   mixins: [layerMixin],
   props: {
-    // element size in pixels
-    size: {
-      type: Object,
-      default() {
-        return { width: 0, height: 0 };
-      },
-    },
     // offset in pixels
     offset: {
       type: [Object, Array],
@@ -48,10 +41,9 @@ export default {
       const center = normalizePoint(this.center);
       const offset = normalizePoint(this.offset);
       return {
-        width: `${this.size.width}px`,
-        height: `${this.size.height}px`,
-        left: `${(center.x + offset.x) - (this.size.width / 2)}px`,
-        top: `${(center.y + offset.y) - (this.size.height / 2)}px`,
+        transform: 'translateX(-50%) translateY(-50%)',
+        left: `${center.x + offset.x}px`,
+        top: `${center.y + offset.y}px`,
       };
     },
   },

--- a/test/specs/GeojsWidgetLayer.spec.js
+++ b/test/specs/GeojsWidgetLayer.spec.js
@@ -38,21 +38,18 @@ describe('GeojsWidgetLayer.vue', () => {
     const layer = wrapper.vm.$geojsLayer;
     expect(layer.canvas().text()).to.equal('Test component');
   });
-
-  it('mounted with correct size', () => {
+  it('mounted with css transform', () => {
     const wrapper = mountLayer({
       propsData: {
-        size: { width: 300, height: 30 },
+        position: [10, 5],
       },
     });
-    expect(wrapper.find('.widget-content').element.style.width).to.equal('300px');
-    expect(wrapper.find('.widget-content').element.style.height).to.equal('30px');
+    expect(wrapper.vm.cssPosition.transform).to.equal('translateX(-50%) translateY(-50%)');
   });
   it('mounted with correct position', () => {
     const position = { x: 0, y: 0 };
     const wrapper = mountLayer({
       propsData: {
-        size: { width: 100, height: 50 },
         position,
         offset: [0, 0],
       },
@@ -60,14 +57,13 @@ describe('GeojsWidgetLayer.vue', () => {
 
     expect(gcsToDisplay).to.have.been.calledOnce;
     expect(gcsToDisplay).to.have.been.calledWith(position);
-    expect(wrapper.vm.cssPosition.left).to.equal(`${displayPosition.x - (100 / 2)}px`);
-    expect(wrapper.vm.cssPosition.top).to.equal(`${displayPosition.y - (50 / 2)}px`);
+    expect(wrapper.vm.cssPosition.left).to.equal(`${displayPosition.x}px`);
+    expect(wrapper.vm.cssPosition.top).to.equal(`${displayPosition.y}px`);
   });
   it('mounted with correct position and offset', () => {
     const position = { x: 0, y: 0 };
     const wrapper = mountLayer({
       propsData: {
-        size: { width: 100, height: 50 },
         position,
         offset: [50, -10],
       },
@@ -75,8 +71,8 @@ describe('GeojsWidgetLayer.vue', () => {
 
     expect(gcsToDisplay).to.have.been.calledOnce;
     expect(gcsToDisplay).to.have.been.calledWith(position);
-    expect(wrapper.vm.cssPosition.left).to.equal(`${(displayPosition.x + 50) - (100 / 2)}px`);
-    expect(wrapper.vm.cssPosition.top).to.equal(`${(displayPosition.y - 10) - (50 / 2)}px`);
+    expect(wrapper.vm.cssPosition.left).to.equal(`${displayPosition.x + 50}px`);
+    expect(wrapper.vm.cssPosition.top).to.equal(`${displayPosition.y - 10}px`);
   });
   it('mounted with a geojson position', () => {
     mountLayer({
@@ -92,7 +88,6 @@ describe('GeojsWidgetLayer.vue', () => {
     const position = { x: 0, y: 0 };
     const wrapper = mountLayer({
       propsData: {
-        size: { width: 100, height: 50 },
         position,
         offset: [50, -10],
       },
@@ -106,8 +101,8 @@ describe('GeojsWidgetLayer.vue', () => {
 
     expect(gcsToDisplay).to.have.been.calledTwice;
     expect(gcsToDisplay).to.have.been.calledWith(position);
-    expect(wrapper.vm.cssPosition.left).to.equal(`${(displayPosition.x + 50) - (100 / 2)}px`);
-    expect(wrapper.vm.cssPosition.top).to.equal(`${(displayPosition.y - 10) - (50 / 2)}px`);
+    expect(wrapper.vm.cssPosition.left).to.equal(`${displayPosition.x + 50}px`);
+    expect(wrapper.vm.cssPosition.top).to.equal(`${displayPosition.y - 10}px`);
   });
   it('removes event handler on destroy', () => {
     const wrapper = mountLayer();


### PR DESCRIPTION
As pointed out by @matthewma7, the element centering can be done without knowing an explicit size using the css `transform` property.  The now unnecessary size prop has been removed.

Fixes #42