### PR TITLE
Add "module" and "main" properties in the package.json

### DIFF
--- a/examples/girder/webpack.config.js
+++ b/examples/girder/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = {
   resolve: {
     alias: {
       vue$: 'vue/dist/vue.esm.js',
-      resonantgeo: 'resonantgeo/src',
     },
     extensions: ['*', '.js', '.vue', '.json'],
   },

--- a/examples/layout/webpack.config.js
+++ b/examples/layout/webpack.config.js
@@ -42,7 +42,6 @@ module.exports = {
   resolve: {
     alias: {
       vue$: 'vue/dist/vue.esm.js',
-      resonantgeo: 'resonantgeo/src',
     },
     extensions: ['*', '.js', '.vue', '.json'],
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build": "node build/build.js",
     "commitmsg": "commitlint -e $GIT_PARAMS"
   },
+  "main": "src/index.js",
+  "module": "src/index.js",
   "dependencies": {
     "axios": "^0.18.0",
     "geojs": "^0.16.0",


### PR DESCRIPTION
This change eliminates the need to prefix resonant geo modules with 'src/' (or webpack aliases).