### PR TITLE
Make map viewport prop reactive

### DIFF
--- a/src/components/geojs/GeojsMapViewport.vue
+++ b/src/components/geojs/GeojsMapViewport.vue
@@ -12,6 +12,7 @@
 <script>
 import debounce from 'lodash-es/debounce';
 import geo from 'geojs';
+import { normalizePoint } from './utils';
 
 export default {
   props: {
@@ -39,6 +40,7 @@ export default {
   data() {
     return {
       ready: false,
+      skipNextViewportEvent: false,
     };
   },
   provide() {
@@ -55,6 +57,15 @@ export default {
       deep: true,
       handler() {
         this.$geojsMap.zoomRange(this.zoomRange);
+      },
+    },
+    viewport: {
+      deep: true,
+      handler() {
+        this.skipNextViewportEvent = true;
+        this.$geojsMap.center(normalizePoint(this.viewport.center));
+        this.$geojsMap.zoom(this.viewport.zoom);
+        this.$geojsMap.rotation(this.viewport.rotation);
       },
     },
   },
@@ -93,6 +104,10 @@ export default {
   },
   methods: {
     emitViewportEventsSync() {
+      if (this.skipNextViewportEvent) {
+        this.skipNextViewportEvent = false;
+        return;
+      }
       const center = this.$geojsMap.center();
       this.$emit('update:viewport', {
         center: [center.x, center.y],

--- a/test/specs/GeojsMapViewport.spec.js
+++ b/test/specs/GeojsMapViewport.spec.js
@@ -65,6 +65,31 @@ describe('GeojsMapViewport.vue', () => {
     expect(map.zoomRange()).to.include({ min: 7, max: 12 });
   });
 
+  it('viewport zoom reactivity', () => {
+    const viewport = { zoom: 10 };
+    const wrapper = mount(GeojsMapViewport, {
+      propsData: {
+        debounce: 0,
+        viewport,
+      },
+    });
+    viewport.zoom = 11.5;
+    expect(wrapper.vm.$geojsMap.zoom()).to.equal(11.5);
+  });
+
+  it('viewport center reactivity', () => {
+    const viewport = { center: [0, 0] };
+    const wrapper = mount(GeojsMapViewport, {
+      propsData: {
+        debounce: 0,
+        viewport,
+      },
+    });
+    viewport.center = [10, 5];
+    expect(wrapper.vm.$geojsMap.center().x).to.be.closeTo(10, 1e-6);
+    expect(wrapper.vm.$geojsMap.center().y).to.be.closeTo(5, 1e-6);
+  });
+
   it('provides properties to child elements', () => {
     const wrapper = mount(GeojsMapViewport);
     const provides = wrapper.vm.$options.provide();


### PR DESCRIPTION
This change allows users of the GeojsMapViewport to request a viewport
(map center, zoom, rotation) by mutating the `viewport` prop.

This implementation is not perfect, but should satisify most use cases
without major performance implications.  Due to constraints on the
viewport (via clamping), existing user interactions, transitions, and
numerical artifacts, the requested viewport might not be honored.  In
this case, the `update:viewport` event will *not* be retriggered with
the real value.  This is done to avoid infinite update loops that would
have to be handled by the user of the component.

If there are issues with this approach, we could add a new event that
fires synchronously with the "real" viewport that is not attached to a
prop.

Fixes #43