### PR TITLE
Update Vuetify to version 1.1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ jobs:
           name: Install web deps
           command: yarn
       - run:
+          name: Install girder example web deps
+          command: yarn --cwd examples/girder
+      - run:
+          name: Install layout example web deps
+          command: yarn --cwd examples/layout
+      - run:
           name: Run web tests
           command: yarn test
       - run:
@@ -25,6 +31,8 @@ jobs:
       - save_cache:
           paths:
             - node_modules
+            - examples/girder/node_modules
+            - examples/layout/node_modules
           key: web-dependencies-{{ checksum "yarn.lock" }}
 
   release:

--- a/examples/girder/package-lock.json
+++ b/examples/girder/package-lock.json
@@ -70,9 +70,9 @@
       }
     },
     "ajv": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-      "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -519,9 +519,9 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
-      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
+      "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^1.0.0",
@@ -926,9 +926,9 @@
       }
     },
     "babel-preset-env": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
@@ -958,7 +958,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
         "babel-plugin-transform-exponentiation-operator": "^6.22.0",
         "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^2.1.2",
+        "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
       }
@@ -1267,14 +1267,15 @@
       }
     },
     "browserify-des": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -1312,13 +1313,13 @@
       }
     },
     "browserslist": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000792",
-        "electron-to-chromium": "^1.3.30"
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
       }
     },
     "buffer": {
@@ -1428,15 +1429,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000856",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000856.tgz",
-      "integrity": "sha1-++u5mr4VpWVPx3R+u1MVvf3jNY8=",
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000865.tgz",
+      "integrity": "sha1-gv+2TUD3VnYgqsAtOmMgeWiavGs=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000856",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-      "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg==",
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
       "dev": true
     },
     "center-align": {
@@ -1786,25 +1787,32 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
       "dev": true,
       "requires": {
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.4.3",
-        "minimist": "^1.2.0",
-        "object-assign": "^4.1.0",
-        "os-homedir": "^1.0.1",
-        "parse-json": "^2.2.0",
-        "require-from-string": "^1.1.0"
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0",
+        "require-from-string": "^2.0.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },
@@ -1846,22 +1854,24 @@
       }
     },
     "cross-env": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.4.tgz",
-      "integrity": "sha512-Mx8mw6JWhfpYoEk7PGvHxJMLQwQHORAs8+2bX+C1lGQ4h3GkDb1zbzC2Nw85YH9ZQMlO0BHZxMacgrfPmMFxbg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.1.0",
+        "cross-spawn": "^6.0.5",
         "is-windows": "^1.0.0"
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -2231,9 +2241,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.50",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
-      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc=",
+      "version": "1.3.52",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
+      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
       "dev": true
     },
     "elliptic": {
@@ -2499,6 +2509,19 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "expand-brackets": {
@@ -2830,9 +2853,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0"
@@ -3433,9 +3456,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-stdin": {
@@ -3639,13 +3662,13 @@
       "dev": true
     },
     "hash.js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
-      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "he": {
@@ -3676,9 +3699,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "hpack.js": {
@@ -3940,6 +3963,24 @@
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
+    "import-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+      "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+      "dev": true,
+      "requires": {
+        "import-from": "^2.1.0"
+      }
+    },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      }
+    },
     "import-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
@@ -4075,9 +4116,9 @@
       }
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-data-descriptor": {
@@ -4199,23 +4240,6 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
-      }
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
       }
     },
     "is-path-cwd": {
@@ -4381,6 +4405,12 @@
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4451,6 +4481,15 @@
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4535,12 +4574,12 @@
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -4686,6 +4725,15 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
@@ -4910,9 +4958,9 @@
       "optional": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -4920,7 +4968,6 @@
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
         "is-windows": "^1.0.2",
         "kind-of": "^6.0.2",
         "object.pick": "^1.3.0",
@@ -4953,6 +5000,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
     },
     "node-forge": {
@@ -5284,12 +5337,13 @@
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parseurl": {
@@ -5614,15 +5668,13 @@
       }
     },
     "postcss-load-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
+      "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^2.1.0",
-        "object-assign": "^4.1.0",
-        "postcss-load-options": "^1.2.0",
-        "postcss-load-plugins": "^2.3.0"
+        "cosmiconfig": "^4.0.0",
+        "import-cwd": "^2.0.0"
       }
     },
     "postcss-load-options": {
@@ -5633,6 +5685,44 @@
       "requires": {
         "cosmiconfig": "^2.1.0",
         "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+          "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+          "dev": true,
+          "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "require-from-string": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+          "dev": true
+        }
       }
     },
     "postcss-load-plugins": {
@@ -5643,17 +5733,55 @@
       "requires": {
         "cosmiconfig": "^2.1.1",
         "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+          "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+          "dev": true,
+          "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "require-from-string": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+          "dev": true
+        }
       }
     },
     "postcss-loader": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.4.tgz",
-      "integrity": "sha512-L2p654oK945B/gDFUGgOhh7uzj19RWoY1SVMeJVoKno1H2MdbQ0RppR/28JGju4pMb22iRC7BJ9aDzbxXSLf4A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
+      "integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
         "postcss": "^6.0.0",
-        "postcss-load-config": "^1.2.0",
+        "postcss-load-config": "^2.0.0",
         "schema-utils": "^0.4.0"
       },
       "dependencies": {
@@ -6254,9 +6382,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
       "dev": true
     },
     "private": {
@@ -6813,9 +6941,9 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -6872,7 +7000,7 @@
         "vue": "^2.5.16",
         "vue-async-computed": "^3.3.1",
         "vue-avatar": "^2.1.5",
-        "vuetify": "1.0.19"
+        "vuetify": "1.1.4"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -6895,6 +7023,10 @@
           "dependencies": {
             "jsesc": {
               "version": "2.5.1",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.5.7",
               "bundled": true
             }
           }
@@ -6973,6 +7105,10 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "globals": {
+              "version": "11.7.0",
+              "bundled": true
             }
           }
         },
@@ -6992,6 +7128,7 @@
           }
         },
         "@commitlint/cli": {
+          "version": "6.2.0",
           "bundled": true,
           "requires": {
             "@commitlint/format": "^6.1.3",
@@ -7014,37 +7151,11 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.2.0"
               }
-            },
-            "get-stdin": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "meow": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "camelcase-keys": "^4.0.0",
-                "decamelize-keys": "^1.0.0",
-                "loud-rejection": "^1.0.0",
-                "minimist": "^1.1.3",
-                "minimist-options": "^3.0.1",
-                "normalize-package-data": "^2.3.4",
-                "read-pkg-up": "^3.0.0",
-                "redent": "^2.0.0",
-                "trim-newlines": "^2.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
-              }
             }
           }
         },
         "@commitlint/config-conventional": {
+          "version": "6.1.3",
           "bundled": true
         },
         "@commitlint/ensure": {
@@ -7098,7 +7209,6 @@
             "@commitlint/execute-rule": "^6.1.3",
             "@commitlint/resolve-extends": "^6.1.3",
             "babel-runtime": "^6.23.0",
-            "cosmiconfig": "^4.0.0",
             "lodash.merge": "4.6.1",
             "lodash.mergewith": "4.6.1",
             "lodash.pick": "4.4.0",
@@ -7107,17 +7217,7 @@
           },
           "dependencies": {
             "cosmiconfig": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.9.0",
-                "parse-json": "^4.0.0",
-                "require-from-string": "^2.0.1"
-              }
-            },
-            "require-from-string": {
-              "version": "2.0.2",
+              "version": "",
               "bundled": true
             }
           }
@@ -7130,30 +7230,12 @@
           "version": "6.1.3",
           "bundled": true,
           "requires": {
-            "conventional-changelog-angular": "^1.3.3",
-            "conventional-commits-parser": "^2.1.0"
+            "conventional-changelog-angular": "^1.3.3"
           },
           "dependencies": {
-            "conventional-changelog-angular": {
-              "version": "1.6.6",
-              "bundled": true,
-              "requires": {
-                "compare-func": "^1.3.1",
-                "q": "^1.5.1"
-              }
-            },
             "conventional-commits-parser": {
-              "version": "2.1.7",
-              "bundled": true,
-              "requires": {
-                "JSONStream": "^1.0.4",
-                "is-text-path": "^1.0.0",
-                "lodash": "^4.2.1",
-                "meow": "^4.0.0",
-                "split2": "^2.0.0",
-                "through2": "^2.0.0",
-                "trim-off-newlines": "^1.0.0"
-              }
+              "version": "",
+              "bundled": true
             }
           }
         },
@@ -7255,6 +7337,27 @@
             "lodash": "^4.17.4"
           },
           "dependencies": {
+            "conventional-changelog-angular": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
+              }
+            },
+            "conventional-commits-parser": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
+              }
+            },
             "debug": {
               "version": "3.1.0",
               "bundled": true,
@@ -7295,6 +7398,15 @@
                 "ms": "2.0.0"
               }
             },
+            "fs-extra": {
+              "version": "6.0.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            },
             "globby": {
               "version": "8.0.1",
               "bundled": true,
@@ -7308,12 +7420,15 @@
                 "slash": "^1.0.0"
               }
             },
+            "jsonfile": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            },
             "mime": {
               "version": "2.3.1",
-              "bundled": true
-            },
-            "pify": {
-              "version": "3.0.0",
               "bundled": true
             },
             "url-join": {
@@ -7343,6 +7458,26 @@
             "detect-indent": {
               "version": "5.0.0",
               "bundled": true
+            },
+            "fs-extra": {
+              "version": "6.0.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            },
+            "jsonfile": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            },
+            "normalize-url": {
+              "version": "3.0.1",
+              "bundled": true
             }
           }
         },
@@ -7361,6 +7496,27 @@
             "lodash": "^4.17.4"
           },
           "dependencies": {
+            "conventional-changelog-angular": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
+              }
+            },
+            "conventional-commits-parser": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
+              }
+            },
             "debug": {
               "version": "3.1.0",
               "bundled": true,
@@ -7414,21 +7570,6 @@
                 "is-obj": "^1.0.0"
               }
             },
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.6.1",
-                  "bundled": true
-                }
-              }
-            },
             "postcss-selector-parser": {
               "version": "3.1.1",
               "bundled": true,
@@ -7437,10 +7578,15 @@
                 "indexes-of": "^1.0.1",
                 "uniq": "^1.0.1"
               }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
             }
           }
         },
         "@vue/test-utils": {
+          "version": "1.0.0-beta.17",
           "bundled": true,
           "requires": {
             "lodash": "^4.17.4"
@@ -7455,7 +7601,7 @@
           }
         },
         "abbrev": {
-          "version": "1.1.1",
+          "version": "1.0.9",
           "bundled": true
         },
         "accepts": {
@@ -7467,7 +7613,7 @@
           }
         },
         "acorn": {
-          "version": "4.0.13",
+          "version": "5.7.1",
           "bundled": true
         },
         "acorn-dynamic-import": {
@@ -7475,6 +7621,12 @@
           "bundled": true,
           "requires": {
             "acorn": "^4.0.3"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            }
           }
         },
         "acorn-globals": {
@@ -7482,6 +7634,12 @@
           "bundled": true,
           "requires": {
             "acorn": "^4.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            }
           }
         },
         "acorn-jsx": {
@@ -7532,27 +7690,8 @@
           }
         },
         "ajv-keywords": {
-          "version": "3.2.0",
-          "bundled": true,
-          "dependencies": {
-            "ajv": {
-              "bundled": true,
-              "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.1"
-              }
-            },
-            "fast-deep-equal": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.4.1",
-              "bundled": true
-            }
-          }
+          "version": "2.1.1",
+          "bundled": true
         },
         "align-text": {
           "version": "0.1.4",
@@ -7561,6 +7700,15 @@
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
             "repeat-string": "^1.5.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "alphanum-sort": {
@@ -7598,6 +7746,11 @@
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -7625,11 +7778,91 @@
           "bundled": true
         },
         "anymatch": {
-          "version": "2.0.0",
+          "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
           }
         },
         "aproba": {
@@ -7760,7 +7993,7 @@
           "bundled": true
         },
         "ast-types": {
-          "version": "0.11.4",
+          "version": "0.11.5",
           "bundled": true,
           "optional": true
         },
@@ -7788,6 +8021,7 @@
           "bundled": true
         },
         "autoprefixer": {
+          "version": "8.6.3",
           "bundled": true,
           "requires": {
             "browserslist": "^3.2.8",
@@ -7796,29 +8030,6 @@
             "num2fraction": "^1.2.2",
             "postcss": "^6.0.22",
             "postcss-value-parser": "^3.2.3"
-          },
-          "dependencies": {
-            "browserslist": {
-              "version": "3.2.8",
-              "bundled": true,
-              "requires": {
-                "caniuse-lite": "^1.0.30000844",
-                "electron-to-chromium": "^1.3.47"
-              }
-            },
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "aws-sign2": {
@@ -7838,6 +8049,7 @@
           }
         },
         "axios-mock-adapter": {
+          "version": "1.15.0",
           "bundled": true,
           "requires": {
             "deep-equal": "^1.0.1"
@@ -7896,9 +8108,16 @@
             "private": "^0.1.8",
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "babel-eslint": {
+          "version": "8.2.3",
           "bundled": true,
           "requires": {
             "@babel/code-frame": "7.0.0-beta.44",
@@ -7927,6 +8146,12 @@
             "lodash": "^4.17.4",
             "source-map": "^0.5.7",
             "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "babel-helper-bindify-decorators": {
@@ -8054,6 +8279,7 @@
           }
         },
         "babel-helper-vue-jsx-merge-props": {
+          "version": "2.0.3",
           "bundled": true
         },
         "babel-helpers": {
@@ -8065,6 +8291,7 @@
           }
         },
         "babel-loader": {
+          "version": "7.1.4",
           "bundled": true,
           "requires": {
             "find-cache-dir": "^1.0.0",
@@ -8087,6 +8314,7 @@
           }
         },
         "babel-plugin-istanbul": {
+          "version": "4.1.6",
           "bundled": true,
           "requires": {
             "babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -8120,6 +8348,7 @@
           "bundled": true
         },
         "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
           "bundled": true
         },
         "babel-plugin-syntax-object-rest-spread": {
@@ -8355,18 +8584,12 @@
           "bundled": true,
           "requires": {
             "babel-helper-regex": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "regexpu-core": "^2.0.0"
+            "babel-runtime": "^6.22.0"
           },
           "dependencies": {
             "regexpu-core": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "regenerate": "^1.2.1",
-                "regjsgen": "^0.2.0",
-                "regjsparser": "^0.1.4"
-              }
+              "version": "",
+              "bundled": true
             }
           }
         },
@@ -8395,6 +8618,7 @@
           }
         },
         "babel-plugin-transform-runtime": {
+          "version": "6.23.0",
           "bundled": true,
           "requires": {
             "babel-runtime": "^6.22.0"
@@ -8409,6 +8633,7 @@
           }
         },
         "babel-plugin-transform-vue-jsx": {
+          "version": "3.7.0",
           "bundled": true,
           "requires": {
             "esutils": "^2.0.2"
@@ -8421,9 +8646,16 @@
             "babel-runtime": "^6.26.0",
             "core-js": "^2.5.0",
             "regenerator-runtime": "^0.10.5"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "bundled": true
+            }
           }
         },
         "babel-preset-env": {
+          "version": "1.7.0",
           "bundled": true,
           "requires": {
             "babel-plugin-check-es2015-constants": "^6.22.0",
@@ -8456,19 +8688,10 @@
             "browserslist": "^3.2.6",
             "invariant": "^2.2.2",
             "semver": "^5.3.0"
-          },
-          "dependencies": {
-            "browserslist": {
-              "version": "3.2.8",
-              "bundled": true,
-              "requires": {
-                "caniuse-lite": "^1.0.30000844",
-                "electron-to-chromium": "^1.3.47"
-              }
-            }
           }
         },
         "babel-preset-stage-2": {
+          "version": "6.24.1",
           "bundled": true,
           "requires": {
             "babel-plugin-syntax-dynamic-import": "^6.18.0",
@@ -8507,12 +8730,6 @@
           "requires": {
             "core-js": "^2.4.0",
             "regenerator-runtime": "^0.11.0"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.11.1",
-              "bundled": true
-            }
           }
         },
         "babel-template": {
@@ -8539,12 +8756,6 @@
             "globals": "^9.18.0",
             "invariant": "^2.2.2",
             "lodash": "^4.17.4"
-          },
-          "dependencies": {
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            }
           }
         },
         "babel-types": {
@@ -8566,7 +8777,7 @@
           "bundled": true
         },
         "balanced-match": {
-          "version": "0.4.2",
+          "version": "1.0.0",
           "bundled": true
         },
         "base": {
@@ -8587,6 +8798,29 @@
               "bundled": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -8676,6 +8910,11 @@
                 "string_decoder": "~0.10.x",
                 "util-deprecate": "~1.0.1"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -8746,12 +8985,6 @@
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
-          },
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            }
           }
         },
         "braces": {
@@ -8768,6 +9001,15 @@
             "snapdragon-node": "^2.0.1",
             "split-string": "^3.0.2",
             "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "brorand": {
@@ -8837,11 +9079,11 @@
           }
         },
         "browserslist": {
-          "version": "1.7.7",
+          "version": "3.2.8",
           "bundled": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
           }
         },
         "btoa-lite": {
@@ -8916,12 +9158,6 @@
             "ssri": "^5.2.4",
             "unique-filename": "^1.1.0",
             "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            }
           }
         },
         "cache-base": {
@@ -8964,6 +9200,10 @@
                 "query-string": "^5.0.1",
                 "sort-keys": "^2.0.0"
               }
+            },
+            "prepend-http": {
+              "version": "2.0.0",
+              "bundled": true
             },
             "query-string": {
               "version": "5.1.1",
@@ -9021,12 +9261,6 @@
             "camelcase": "^4.1.0",
             "map-obj": "^2.0.0",
             "quick-lru": "^1.0.0"
-          },
-          "dependencies": {
-            "map-obj": {
-              "version": "2.0.0",
-              "bundled": true
-            }
           }
         },
         "caniuse-api": {
@@ -9037,6 +9271,16 @@
             "caniuse-db": "^1.0.30000529",
             "lodash.memoize": "^4.1.2",
             "lodash.uniq": "^4.5.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "1.7.7",
+              "bundled": true,
+              "requires": {
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
+              }
+            }
           }
         },
         "caniuse-db": {
@@ -9108,49 +9352,28 @@
           "bundled": true
         },
         "chokidar": {
-          "version": "2.0.4",
+          "version": "1.7.0",
           "bundled": true,
           "requires": {
-            "anymatch": "^2.0.0",
+            "anymatch": "^1.3.0",
             "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "^2.0.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "lodash.debounce": "^4.0.8",
-            "normalize-path": "^2.1.1",
+            "is-glob": "^2.0.0",
             "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.5"
+            "readdirp": "^2.0.0"
           },
           "dependencies": {
-            "glob-parent": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
-              },
-              "dependencies": {
-                "is-glob": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-extglob": "^2.1.0"
-                  }
-                }
-              }
-            },
             "is-extglob": {
-              "version": "2.1.1",
+              "version": "1.0.0",
               "bundled": true
             },
             "is-glob": {
-              "version": "4.0.0",
+              "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extglob": "^2.1.1"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -9172,7 +9395,7 @@
           }
         },
         "circular-json": {
-          "version": "0.5.4",
+          "version": "0.3.3",
           "bundled": true
         },
         "clap": {
@@ -9211,6 +9434,15 @@
             "define-property": "^0.2.5",
             "isobject": "^3.0.0",
             "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
           }
         },
         "clean-css": {
@@ -9218,6 +9450,12 @@
           "bundled": true,
           "requires": {
             "source-map": "0.5.x"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "clean-stack": {
@@ -9253,29 +9491,17 @@
           "bundled": true
         },
         "cliui": {
-          "version": "3.2.0",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
           },
           "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true
             }
           }
         },
@@ -9342,12 +9568,6 @@
           "bundled": true,
           "requires": {
             "color-name": "^1.0.0"
-          },
-          "dependencies": {
-            "color-name": {
-              "version": "1.1.3",
-              "bundled": true
-            }
           }
         },
         "colormin": {
@@ -9360,7 +9580,7 @@
           }
         },
         "colors": {
-          "version": "1.3.0",
+          "version": "1.1.2",
           "bundled": true
         },
         "combine-lists": {
@@ -9506,7 +9726,7 @@
           "bundled": true
         },
         "conventional-changelog-angular": {
-          "version": "5.0.0",
+          "version": "1.6.6",
           "bundled": true,
           "requires": {
             "compare-func": "^1.3.1",
@@ -9548,7 +9768,7 @@
           }
         },
         "conventional-commits-parser": {
-          "version": "3.0.0",
+          "version": "2.1.7",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.0.4",
@@ -9589,6 +9809,7 @@
           "bundled": true
         },
         "copy-webpack-plugin": {
+          "version": "4.5.1",
           "bundled": true,
           "requires": {
             "cacache": "^10.0.4",
@@ -9599,23 +9820,10 @@
             "minimatch": "^3.0.4",
             "p-limit": "^1.0.0",
             "serialize-javascript": "^1.4.0"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "^2.1.1"
-              }
-            }
           }
         },
         "core-js": {
-          "version": "2.5.6",
+          "version": "2.5.7",
           "bundled": true
         },
         "core-util-is": {
@@ -9623,25 +9831,13 @@
           "bundled": true
         },
         "cosmiconfig": {
-          "version": "2.2.2",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
             "is-directory": "^0.3.1",
-            "js-yaml": "^3.4.3",
-            "minimist": "^1.2.0",
-            "object-assign": "^4.1.0",
-            "os-homedir": "^1.0.1",
-            "parse-json": "^2.2.0",
-            "require-from-string": "^1.1.0"
-          },
-          "dependencies": {
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "error-ex": "^1.2.0"
-              }
-            }
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
           }
         },
         "create-ecdh": {
@@ -9676,30 +9872,25 @@
           }
         },
         "cross-env": {
+          "version": "5.2.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "^6.0.5",
             "is-windows": "^1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
+              "version": "",
+              "bundled": true
             }
           }
         },
         "cross-spawn": {
-          "version": "5.1.0",
+          "version": "6.0.5",
           "bundled": true,
           "requires": {
-            "lru-cache": "^4.0.1",
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
           }
@@ -9734,6 +9925,7 @@
           "bundled": true
         },
         "css-loader": {
+          "version": "0.28.11",
           "bundled": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
@@ -9750,6 +9942,54 @@
             "postcss-modules-values": "^1.3.0",
             "postcss-value-parser": "^3.3.0",
             "source-list-map": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "css-parse": {
@@ -9764,16 +10004,6 @@
             "css-what": "2.1",
             "domutils": "1.5.1",
             "nth-check": "~1.0.1"
-          },
-          "dependencies": {
-            "domutils": {
-              "version": "1.5.1",
-              "bundled": true,
-              "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
-              }
-            }
           }
         },
         "css-selector-tokenizer": {
@@ -9783,6 +10013,17 @@
             "cssesc": "^0.1.0",
             "fastparse": "^1.1.1",
             "regexpu-core": "^1.0.0"
+          },
+          "dependencies": {
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            }
           }
         },
         "css-what": {
@@ -9831,6 +10072,10 @@
             "postcss-zindex": "^2.0.1"
           },
           "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
             "autoprefixer": {
               "version": "6.7.7",
               "bundled": true,
@@ -9842,6 +10087,56 @@
                 "postcss": "^5.2.16",
                 "postcss-value-parser": "^3.2.3"
               }
+            },
+            "browserslist": {
+              "version": "1.7.7",
+              "bundled": true,
+              "requires": {
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
             }
           }
         },
@@ -9851,6 +10146,12 @@
           "requires": {
             "clap": "^1.0.9",
             "source-map": "^0.5.3"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "cuint": {
@@ -9873,6 +10174,7 @@
           "bundled": true
         },
         "cz-conventional-changelog": {
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
             "conventional-commit-types": "^2.0.0",
@@ -9941,12 +10243,39 @@
                 "map-obj": "^1.0.0"
               }
             },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "bundled": true
+            },
             "indent-string": {
               "version": "2.1.0",
               "bundled": true,
               "requires": {
                 "repeating": "^2.0.0"
               }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "bundled": true
             },
             "meow": {
               "version": "3.7.0",
@@ -9964,12 +10293,63 @@
                 "trim-newlines": "^1.0.0"
               }
             },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
             "redent": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
                 "indent-string": "^2.1.0",
                 "strip-indent": "^1.0.1"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
               }
             },
             "strip-indent": {
@@ -10006,6 +10386,12 @@
           "requires": {
             "decamelize": "^1.1.0",
             "map-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "map-obj": {
+              "version": "1.0.1",
+              "bundled": true
+            }
           }
         },
         "decode-uri-component": {
@@ -10054,56 +10440,35 @@
           }
         },
         "define-property": {
-          "version": "0.2.5",
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
-              "version": "0.1.6",
+              "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
-              "version": "0.1.4",
+              "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
-              "version": "0.1.6",
+              "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true
             }
           }
         },
@@ -10117,64 +10482,47 @@
           "optional": true,
           "requires": {
             "ast-types": "0.x.x",
-            "escodegen": "1.x.x",
             "esprima": "3.x.x"
           },
           "dependencies": {
             "escodegen": {
-              "version": "1.10.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
-              }
+              "version": "",
+              "bundled": true
             },
             "esprima": {
               "version": "3.1.3",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.6.1",
               "bundled": true,
               "optional": true
             }
           }
         },
         "del": {
-          "version": "3.0.0",
+          "version": "2.2.2",
           "bundled": true,
           "requires": {
-            "globby": "^6.1.0",
+            "globby": "^5.0.0",
             "is-path-cwd": "^1.0.0",
             "is-path-in-cwd": "^1.0.0",
-            "p-map": "^1.1.1",
-            "pify": "^3.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
             "rimraf": "^2.2.8"
           },
           "dependencies": {
             "globby": {
-              "version": "6.1.0",
+              "version": "5.0.0",
               "bundled": true,
               "requires": {
                 "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
                 "glob": "^7.0.3",
                 "object-assign": "^4.0.1",
                 "pify": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
-              },
-              "dependencies": {
-                "pify": {
-                  "version": "2.3.0",
-                  "bundled": true
-                }
               }
             },
             "pify": {
-              "version": "3.0.0",
+              "version": "2.3.0",
               "bundled": true
             }
           }
@@ -10259,11 +10607,10 @@
           }
         },
         "doctrine": {
-          "version": "1.5.0",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "^2.0.2"
           }
         },
         "doctypes": {
@@ -10275,6 +10622,12 @@
           "bundled": true,
           "requires": {
             "utila": "~0.3"
+          },
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true
+            }
           }
         },
         "dom-serialize": {
@@ -10317,9 +10670,10 @@
           }
         },
         "domutils": {
-          "version": "1.1.6",
+          "version": "1.5.1",
           "bundled": true,
           "requires": {
+            "dom-serializer": "0",
             "domelementtype": "1"
           }
         },
@@ -10468,13 +10822,12 @@
           }
         },
         "enhanced-resolve": {
-          "version": "3.4.1",
+          "version": "0.9.1",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.4.0",
-            "object-assign": "^4.0.1",
-            "tapable": "^0.2.7"
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
           }
         },
         "ent": {
@@ -10613,27 +10966,19 @@
           "bundled": true
         },
         "escodegen": {
-          "version": "1.8.1",
+          "version": "1.10.0",
           "bundled": true,
           "requires": {
-            "esprima": "^2.7.1",
-            "estraverse": "^1.9.1",
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
             "esutils": "^2.0.2",
             "optionator": "^0.8.1",
-            "source-map": "~0.2.0"
+            "source-map": "~0.6.1"
           },
           "dependencies": {
-            "estraverse": {
-              "version": "1.9.3",
+            "esprima": {
+              "version": "3.1.3",
               "bundled": true
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
             }
           }
         },
@@ -10648,6 +10993,7 @@
           }
         },
         "eslint": {
+          "version": "4.19.1",
           "bundled": true,
           "requires": {
             "ajv": "^5.3.0",
@@ -10694,6 +11040,15 @@
               "version": "3.0.0",
               "bundled": true
             },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
             "debug": {
               "version": "3.1.0",
               "bundled": true,
@@ -10701,15 +11056,8 @@
                 "ms": "2.0.0"
               }
             },
-            "doctrine": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "esutils": "^2.0.2"
-              }
-            },
-            "progress": {
-              "version": "2.0.0",
+            "globals": {
+              "version": "11.7.0",
               "bundled": true
             },
             "strip-ansi": {
@@ -10722,12 +11070,14 @@
           }
         },
         "eslint-config-airbnb-base": {
+          "version": "12.1.0",
           "bundled": true,
           "requires": {
             "eslint-restricted-globals": "^0.1.1"
           }
         },
         "eslint-friendly-formatter": {
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
             "chalk": "^2.0.1",
@@ -10760,6 +11110,7 @@
           }
         },
         "eslint-import-resolver-webpack": {
+          "version": "0.10.0",
           "bundled": true,
           "requires": {
             "array-find": "^1.0.0",
@@ -10772,28 +11123,10 @@
             "node-libs-browser": "^1.0.0 || ^2.0.0",
             "resolve": "^1.4.0",
             "semver": "^5.3.0"
-          },
-          "dependencies": {
-            "enhanced-resolve": {
-              "version": "0.9.1",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.2.0",
-                "tapable": "^0.1.8"
-              }
-            },
-            "memory-fs": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "tapable": {
-              "version": "0.1.10",
-              "bundled": true
-            }
           }
         },
         "eslint-loader": {
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
             "loader-fs-cache": "^1.0.0",
@@ -10809,9 +11142,34 @@
           "requires": {
             "debug": "^2.6.8",
             "pkg-dir": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0"
+              }
+            }
           }
         },
         "eslint-plugin-import": {
+          "version": "2.12.0",
           "bundled": true,
           "requires": {
             "contains-path": "^0.1.0",
@@ -10826,6 +11184,14 @@
             "resolve": "^1.6.0"
           },
           "dependencies": {
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
+              }
+            },
             "load-json-file": {
               "version": "2.0.0",
               "bundled": true,
@@ -10850,6 +11216,10 @@
                 "pify": "^2.0.0"
               }
             },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
             "read-pkg": {
               "version": "2.0.0",
               "bundled": true,
@@ -10870,6 +11240,7 @@
           }
         },
         "eslint-plugin-vue": {
+          "version": "4.5.0",
           "bundled": true,
           "requires": {
             "vue-eslint-parser": "^2.0.3"
@@ -10897,16 +11268,10 @@
           "requires": {
             "acorn": "^5.5.0",
             "acorn-jsx": "^3.0.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "5.7.1",
-              "bundled": true
-            }
           }
         },
         "esprima": {
-          "version": "2.7.3",
+          "version": "4.0.0",
           "bundled": true
         },
         "esquery": {
@@ -10970,7 +11335,6 @@
           "version": "0.10.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
             "get-stream": "^3.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
@@ -10980,15 +11344,8 @@
           },
           "dependencies": {
             "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
+              "version": "",
+              "bundled": true
             }
           }
         },
@@ -11011,6 +11368,22 @@
               "requires": {
                 "expand-range": "^0.1.0"
               }
+            },
+            "expand-range": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "is-number": "^0.1.1",
+                "repeat-string": "^0.2.2"
+              }
+            },
+            "is-number": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "0.2.2",
+              "bundled": true
             }
           }
         },
@@ -11025,23 +11398,62 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "expand-range": {
-          "version": "0.1.1",
+          "version": "1.8.2",
           "bundled": true,
           "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
+            "fill-range": "^2.1.0"
           },
           "dependencies": {
-            "is-number": {
-              "version": "0.1.1",
-              "bundled": true
+            "fill-range": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+              }
             },
-            "repeat-string": {
-              "version": "0.2.2",
-              "bundled": true
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
             }
           }
         },
@@ -11114,6 +11526,10 @@
               "version": "0.4.19",
               "bundled": true
             },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "bundled": true
+            },
             "qs": {
               "version": "6.5.1",
               "bundled": true
@@ -11145,15 +11561,15 @@
                 "setprototypeof": {
                   "version": "1.0.3",
                   "bundled": true
-                },
-                "statuses": {
-                  "version": "1.5.0",
-                  "bundled": true
                 }
               }
             },
             "safe-buffer": {
               "version": "5.1.1",
+              "bundled": true
+            },
+            "statuses": {
+              "version": "1.4.0",
               "bundled": true
             }
           }
@@ -11163,10 +11579,20 @@
           "bundled": true
         },
         "extend-shallow": {
-          "version": "2.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
           }
         },
         "external-editor": {
@@ -11198,10 +11624,41 @@
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
             }
           }
         },
         "extract-text-webpack-plugin": {
+          "version": "4.0.0-beta.0",
           "bundled": true,
           "requires": {
             "async": "^2.4.1",
@@ -11256,17 +11713,6 @@
                   }
                 }
               }
-            },
-            "is-extglob": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "^2.1.1"
-              }
             }
           }
         },
@@ -11312,6 +11758,7 @@
           }
         },
         "file-loader": {
+          "version": "1.1.11",
           "bundled": true,
           "requires": {
             "loader-utils": "^1.0.2",
@@ -11339,6 +11786,15 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1",
             "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "finalhandler": {
@@ -11367,15 +11823,6 @@
             "commondir": "^1.0.1",
             "make-dir": "^1.0.0",
             "pkg-dir": "^2.0.0"
-          },
-          "dependencies": {
-            "pkg-dir": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "^2.1.0"
-              }
-            }
           }
         },
         "find-root": {
@@ -11402,39 +11849,13 @@
           "bundled": true,
           "requires": {
             "circular-json": "^0.3.1",
-            "del": "^2.0.2",
             "graceful-fs": "^4.1.2",
             "write": "^0.2.1"
           },
           "dependencies": {
-            "circular-json": {
-              "version": "0.3.3",
-              "bundled": true
-            },
             "del": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "globby": "^5.0.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "rimraf": "^2.2.8"
-              }
-            },
-            "globby": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
+              "version": "",
+              "bundled": true
             }
           }
         },
@@ -11510,6 +11931,7 @@
           "bundled": true
         },
         "friendly-errors-webpack-plugin": {
+          "version": "1.7.0",
           "bundled": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11551,12 +11973,12 @@
           "bundled": true
         },
         "fs-extra": {
-          "version": "6.0.1",
+          "version": "1.0.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "fs-write-stream-atomic": {
@@ -11597,6 +12019,11 @@
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -11638,7 +12065,7 @@
           "bundled": true
         },
         "get-stdin": {
-          "version": "4.0.1",
+          "version": "5.0.1",
           "bundled": true
         },
         "get-stream": {
@@ -11735,6 +12162,19 @@
           "requires": {
             "glob-parent": "^2.0.0",
             "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
           }
         },
         "glob-parent": {
@@ -11742,6 +12182,19 @@
           "bundled": true,
           "requires": {
             "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
           }
         },
         "glob-to-regexp": {
@@ -11756,7 +12209,7 @@
           }
         },
         "globals": {
-          "version": "11.7.0",
+          "version": "9.18.0",
           "bundled": true
         },
         "globby": {
@@ -11769,12 +12222,6 @@
             "ignore": "^3.3.5",
             "pify": "^3.0.0",
             "slash": "^1.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "got": {
@@ -11798,12 +12245,6 @@
             "timed-out": "^4.0.1",
             "url-parse-lax": "^3.0.0",
             "url-to-options": "^1.0.1"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "graceful-fs": {
@@ -11824,12 +12265,6 @@
           "requires": {
             "duplexer": "^0.1.1",
             "pify": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "hammerjs": {
@@ -11860,6 +12295,23 @@
               "bundled": true,
               "requires": {
                 "amdefine": ">=0.0.4"
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true,
+                  "optional": true
+                }
               }
             }
           }
@@ -11908,7 +12360,7 @@
           "bundled": true
         },
         "has-flag": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true
         },
         "has-symbol-support-x": {
@@ -12062,23 +12514,10 @@
             "param-case": "2.1.x",
             "relateurl": "0.2.x",
             "uglify-js": "3.3.x"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "uglify-js": {
-              "version": "3.3.28",
-              "bundled": true,
-              "requires": {
-                "commander": "~2.15.0",
-                "source-map": "~0.6.1"
-              }
-            }
           }
         },
         "html-webpack-plugin": {
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
             "html-minifier": "^3.2.3",
@@ -12116,6 +12555,13 @@
             "readable-stream": "1.0"
           },
           "dependencies": {
+            "domutils": {
+              "version": "1.1.6",
+              "bundled": true,
+              "requires": {
+                "domelementtype": "1"
+              }
+            },
             "isarray": {
               "version": "0.0.1",
               "bundled": true
@@ -12129,6 +12575,10 @@
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
             }
           }
         },
@@ -12148,12 +12598,6 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
             "statuses": ">= 1.4.0 < 2"
-          },
-          "dependencies": {
-            "statuses": {
-              "version": "1.5.0",
-              "bundled": true
-            }
           }
         },
         "http-parser-js": {
@@ -12223,29 +12667,17 @@
                 "is-posix-bracket": "^0.1.0"
               }
             },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "^2.1.0"
-              }
-            },
             "extglob": {
               "version": "0.3.2",
               "bundled": true,
               "requires": {
                 "is-extglob": "^1.0.0"
-              }
-            },
-            "fill-range": {
-              "version": "2.2.4",
-              "bundled": true,
-              "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+              },
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
               }
             },
             "is-glob": {
@@ -12253,26 +12685,13 @@
               "bundled": true,
               "requires": {
                 "is-extglob": "^2.1.0"
-              },
-              "dependencies": {
-                "is-extglob": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
               }
             },
-            "is-number": {
-              "version": "2.1.0",
+            "kind-of": {
+              "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "kind-of": "^3.0.2"
-              }
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "1.0.0"
+                "is-buffer": "^1.1.5"
               }
             },
             "micromatch": {
@@ -12294,6 +12713,10 @@
                 "regex-cache": "^0.4.2"
               },
               "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
                 "is-glob": {
                   "version": "2.0.1",
                   "bundled": true,
@@ -12301,6 +12724,13 @@
                     "is-extglob": "^1.0.0"
                   }
                 }
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
               }
             }
           }
@@ -12348,17 +12778,12 @@
           }
         },
         "husky": {
+          "version": "0.14.3",
           "bundled": true,
           "requires": {
             "is-ci": "^1.0.10",
             "normalize-path": "^1.0.0",
             "strip-indent": "^2.0.0"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "1.0.0",
-              "bundled": true
-            }
           }
         },
         "iconv-lite": {
@@ -12377,25 +12802,10 @@
           "bundled": true,
           "requires": {
             "postcss": "^6.0.1"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "ieee754": {
-          "version": "1.1.11",
+          "version": "1.1.12",
           "bundled": true
         },
         "iferr": {
@@ -12425,15 +12835,6 @@
           "requires": {
             "pkg-dir": "^2.0.0",
             "resolve-cwd": "^2.0.0"
-          },
-          "dependencies": {
-            "pkg-dir": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "^2.1.0"
-              }
-            }
           }
         },
         "imurmurhash": {
@@ -12474,6 +12875,7 @@
           "bundled": true
         },
         "inject-loader": {
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
             "babel-core": "~6"
@@ -12531,12 +12933,39 @@
                 "map-obj": "^1.0.0"
               }
             },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "bundled": true
+            },
             "indent-string": {
               "version": "2.1.0",
               "bundled": true,
               "requires": {
                 "repeating": "^2.0.0"
               }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "bundled": true
             },
             "meow": {
               "version": "3.7.0",
@@ -12554,12 +12983,63 @@
                 "trim-newlines": "^1.0.0"
               }
             },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
             "redent": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
                 "indent-string": "^2.1.0",
                 "strip-indent": "^1.0.1"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
               }
             },
             "strip-indent": {
@@ -12611,15 +13091,18 @@
           "bundled": true
         },
         "is-accessor-descriptor": {
-          "version": "1.0.0",
+          "version": "0.1.6",
           "bundled": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
-              "version": "6.0.2",
-              "bundled": true
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
             }
           }
         },
@@ -12657,15 +13140,18 @@
           }
         },
         "is-data-descriptor": {
-          "version": "1.0.0",
+          "version": "0.1.4",
           "bundled": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
-              "version": "6.0.2",
-              "bundled": true
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
             }
           }
         },
@@ -12674,16 +13160,16 @@
           "bundled": true
         },
         "is-descriptor": {
-          "version": "1.0.2",
+          "version": "0.1.6",
           "bundled": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
-              "version": "6.0.2",
+              "version": "5.1.0",
               "bundled": true
             }
           }
@@ -12709,6 +13195,12 @@
           "requires": {
             "acorn": "~4.0.2",
             "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            }
           }
         },
         "is-extendable": {
@@ -12716,7 +13208,7 @@
           "bundled": true
         },
         "is-extglob": {
-          "version": "1.0.0",
+          "version": "2.1.1",
           "bundled": true
         },
         "is-finite": {
@@ -12731,10 +13223,10 @@
           "bundled": true
         },
         "is-glob": {
-          "version": "2.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-my-ip-valid": {
@@ -12759,6 +13251,15 @@
           "bundled": true,
           "requires": {
             "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "is-obj": {
@@ -12939,12 +13440,27 @@
             "wordwrap": "^1.0.0"
           },
           "dependencies": {
-            "abbrev": {
-              "version": "1.0.9",
-              "bundled": true
-            },
             "async": {
               "version": "1.5.2",
+              "bundled": true
+            },
+            "escodegen": {
+              "version": "1.8.1",
+              "bundled": true,
+              "requires": {
+                "esprima": "^2.7.1",
+                "estraverse": "^1.9.1",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.2.0"
+              }
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "bundled": true
+            },
+            "estraverse": {
+              "version": "1.9.3",
               "bundled": true
             },
             "glob": {
@@ -12965,6 +13481,14 @@
             "resolve": {
               "version": "1.1.7",
               "bundled": true
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
             },
             "supports-color": {
               "version": "3.2.3",
@@ -13026,12 +13550,6 @@
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.0",
-              "bundled": true
-            }
           }
         },
         "jsbn": {
@@ -13080,7 +13598,7 @@
           "bundled": true
         },
         "jsonfile": {
-          "version": "4.0.0",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -13118,6 +13636,7 @@
           "bundled": true
         },
         "karma": {
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
             "bluebird": "^3.3.0",
@@ -13147,122 +13666,10 @@
             "source-map": "^0.6.1",
             "tmp": "0.0.33",
             "useragent": "2.2.1"
-          },
-          "dependencies": {
-            "anymatch": {
-              "version": "1.3.2",
-              "bundled": true,
-              "requires": {
-                "micromatch": "^2.1.5",
-                "normalize-path": "^2.0.0"
-              }
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "^1.0.1"
-              }
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
-              }
-            },
-            "chokidar": {
-              "version": "1.7.0",
-              "bundled": true,
-              "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "is-posix-bracket": "^0.1.0"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "^2.1.0"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "fill-range": {
-              "version": "2.2.4",
-              "bundled": true,
-              "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
-              }
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              }
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true,
-              "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "karma-coverage": {
+          "version": "1.1.2",
           "bundled": true,
           "requires": {
             "dateformat": "^1.0.6",
@@ -13270,15 +13677,23 @@
             "lodash": "^4.17.0",
             "minimatch": "^3.0.0",
             "source-map": "^0.5.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "karma-mocha": {
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
             "minimist": "1.2.0"
           }
         },
         "karma-phantomjs-launcher": {
+          "version": "1.0.4",
           "bundled": true,
           "requires": {
             "lodash": "^4.0.1",
@@ -13286,59 +13701,48 @@
           }
         },
         "karma-phantomjs-shim": {
+          "version": "1.5.0",
           "bundled": true
         },
         "karma-sinon-chai": {
+          "version": "1.3.4",
           "bundled": true,
           "requires": {
             "lolex": "^1.6.0"
-          },
-          "dependencies": {
-            "lolex": {
-              "version": "1.6.0",
-              "bundled": true
-            }
           }
         },
         "karma-sourcemap-loader": {
+          "version": "0.3.7",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
         },
         "karma-spec-reporter": {
+          "version": "0.0.32",
           "bundled": true,
           "requires": {
             "colors": "^1.1.2"
           }
         },
         "karma-webpack": {
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
             "async": "^2.0.0",
             "babel-runtime": "^6.0.0",
             "loader-utils": "^1.0.0",
             "lodash": "^4.0.0",
-            "source-map": "^0.5.6",
-            "webpack-dev-middleware": "^2.0.6"
+            "source-map": "^0.5.6"
           },
           "dependencies": {
-            "mime": {
-              "version": "2.3.1",
+            "source-map": {
+              "version": "0.5.7",
               "bundled": true
             },
             "webpack-dev-middleware": {
-              "version": "2.0.6",
-              "bundled": true,
-              "requires": {
-                "loud-rejection": "^1.6.0",
-                "memory-fs": "~0.4.1",
-                "mime": "^2.1.0",
-                "path-is-absolute": "^1.0.0",
-                "range-parser": "^1.0.3",
-                "url-join": "^2.0.2",
-                "webpack-log": "^1.0.1"
-              }
+              "version": "",
+              "bundled": true
             }
           }
         },
@@ -13358,11 +13762,8 @@
           "bundled": true
         },
         "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "bundled": true
         },
         "klaw": {
           "version": "1.3.1",
@@ -13429,12 +13830,6 @@
             "parse-json": "^4.0.0",
             "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "loader-fs-cache": {
@@ -13452,6 +13847,28 @@
                 "commondir": "^1.0.1",
                 "mkdirp": "^0.5.1",
                 "pkg-dir": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0"
               }
             }
           }
@@ -13475,15 +13892,6 @@
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
-          },
-          "dependencies": {
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            }
           }
         },
         "lodash": {
@@ -13593,7 +14001,7 @@
           }
         },
         "log4js": {
-          "version": "2.6.1",
+          "version": "2.9.0",
           "bundled": true,
           "requires": {
             "amqplib": "^0.5.2",
@@ -13618,6 +14026,10 @@
               "requires": {
                 "follow-redirects": "1.0.0"
               }
+            },
+            "circular-json": {
+              "version": "0.5.4",
+              "bundled": true
             },
             "debug": {
               "version": "3.1.0",
@@ -13719,6 +14131,11 @@
                 "sshpk": "^1.7.0"
               }
             },
+            "node-uuid": {
+              "version": "1.4.8",
+              "bundled": true,
+              "optional": true
+            },
             "qs": {
               "version": "6.2.3",
               "bundled": true,
@@ -13777,7 +14194,7 @@
           }
         },
         "lolex": {
-          "version": "2.7.0",
+          "version": "1.6.0",
           "bundled": true
         },
         "longest": {
@@ -13813,12 +14230,6 @@
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
-          },
-          "dependencies": {
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
           }
         },
         "mailcomposer": {
@@ -13861,12 +14272,6 @@
           "bundled": true,
           "requires": {
             "pify": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "map-cache": {
@@ -13874,7 +14279,7 @@
           "bundled": true
         },
         "map-obj": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true
         },
         "map-visit": {
@@ -13948,15 +14353,11 @@
           }
         },
         "memory-fs": {
-          "version": "0.4.1",
-          "bundled": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
+          "version": "0.2.0",
+          "bundled": true
         },
         "meow": {
-          "version": "4.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
             "camelcase-keys": "^4.0.0",
@@ -13968,16 +14369,6 @@
             "read-pkg-up": "^3.0.0",
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0"
-          },
-          "dependencies": {
-            "read-pkg-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
-              }
-            }
           }
         },
         "merge-descriptors": {
@@ -13989,12 +14380,6 @@
           "bundled": true,
           "requires": {
             "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "merge2": {
@@ -14022,35 +14407,6 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
-              }
-            },
-            "extend-shallow": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
-              }
-            },
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true
-            }
           }
         },
         "miller-rabin": {
@@ -14158,6 +14514,7 @@
           }
         },
         "mocha": {
+          "version": "5.2.0",
           "bundled": true,
           "requires": {
             "browser-stdout": "1.3.1",
@@ -14234,35 +14591,6 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
-              }
-            },
-            "extend-shallow": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
-              }
-            },
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true
-            }
           }
         },
         "natural-compare": {
@@ -14305,16 +14633,9 @@
             "text-encoding": "^0.6.4"
           },
           "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
+            "lolex": {
+              "version": "2.7.0",
               "bundled": true
-            },
-            "path-to-regexp": {
-              "version": "1.7.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "0.0.1"
-              }
             }
           }
         },
@@ -14367,18 +14688,10 @@
             "url": "^0.11.0",
             "util": "^0.10.3",
             "vm-browserify": "0.0.4"
-          },
-          "dependencies": {
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
           }
         },
         "node-notifier": {
+          "version": "5.2.1",
           "bundled": true,
           "requires": {
             "growly": "^1.3.0",
@@ -14386,11 +14699,6 @@
             "shellwords": "^0.1.1",
             "which": "^1.3.0"
           }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "bundled": true,
-          "optional": true
         },
         "nodemailer": {
           "version": "2.7.2",
@@ -14404,6 +14712,17 @@
             "nodemailer-smtp-pool": "2.8.2",
             "nodemailer-smtp-transport": "2.7.2",
             "socks": "1.1.9"
+          },
+          "dependencies": {
+            "socks": {
+              "version": "1.1.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ip": "^1.1.2",
+                "smart-buffer": "^1.0.4"
+              }
+            }
           }
         },
         "nodemailer-direct-transport": {
@@ -14468,19 +14787,22 @@
           }
         },
         "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
+          "version": "1.0.0",
+          "bundled": true
         },
         "normalize-range": {
           "version": "0.1.2",
           "bundled": true
         },
         "normalize-url": {
-          "version": "3.0.1",
-          "bundled": true
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
@@ -14523,6 +14845,22 @@
             "copy-descriptor": "^0.1.0",
             "define-property": "^0.2.5",
             "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "object-hash": {
@@ -14632,6 +14970,7 @@
           }
         },
         "optimize-css-assets-webpack-plugin": {
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
             "cssnano": "^3.4.0",
@@ -14651,6 +14990,7 @@
           }
         },
         "ora": {
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
             "chalk": "^2.3.1",
@@ -14698,6 +15038,15 @@
             "mem": "^1.1.0"
           },
           "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
             "execa": {
               "version": "0.7.0",
               "bundled": true,
@@ -14744,23 +15093,10 @@
           }
         },
         "p-locate": {
-          "version": "3.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "^2.0.0"
-          },
-          "dependencies": {
-            "p-limit": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "p-limit": "^1.1.0"
           }
         },
         "p-map": {
@@ -14891,6 +15227,10 @@
               "version": "1.10.3",
               "bundled": true
             },
+            "has-flag": {
+              "version": "2.0.0",
+              "bundled": true
+            },
             "mocha": {
               "version": "4.1.0",
               "bundled": true,
@@ -14928,6 +15268,19 @@
             "is-dotfile": "^1.0.0",
             "is-extglob": "^1.0.0",
             "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
           }
         },
         "parse-json": {
@@ -15012,20 +15365,23 @@
           }
         },
         "path-to-regexp": {
-          "version": "0.1.7",
-          "bundled": true
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            }
+          }
         },
         "path-type": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
             "pify": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "pathval": {
@@ -15066,26 +15422,14 @@
             "which": "^1.2.10"
           },
           "dependencies": {
-            "fs-extra": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0",
-                "klaw": "^1.0.0"
-              }
-            },
-            "jsonfile": {
-              "version": "2.4.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
+            "progress": {
+              "version": "1.1.8",
+              "bundled": true
             }
           }
         },
         "pify": {
-          "version": "2.3.0",
+          "version": "3.0.0",
           "bundled": true
         },
         "pinkie": {
@@ -15100,27 +15444,10 @@
           }
         },
         "pkg-dir": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "find-up": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "pinkie-promise": "^2.0.0"
-              }
-            }
+            "find-up": "^2.1.0"
           }
         },
         "pluralize": {
@@ -15147,13 +15474,21 @@
           "bundled": true
         },
         "postcss": {
-          "version": "5.2.18",
+          "version": "6.0.22",
           "bundled": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "postcss-calc": {
+          "version": "5.3.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.2",
+            "postcss-message-helpers": "^2.0.0",
+            "reduce-css-calc": "^1.2.6"
           },
           "dependencies": {
             "ansi-styles": {
@@ -15181,6 +15516,20 @@
               "version": "1.0.0",
               "bundled": true
             },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
@@ -15190,15 +15539,6 @@
             }
           }
         },
-        "postcss-calc": {
-          "version": "5.3.1",
-          "bundled": true,
-          "requires": {
-            "postcss": "^5.0.2",
-            "postcss-message-helpers": "^2.0.0",
-            "reduce-css-calc": "^1.2.6"
-          }
-        },
         "postcss-colormin": {
           "version": "2.2.2",
           "bundled": true,
@@ -15206,6 +15546,54 @@
             "colormin": "^1.0.5",
             "postcss": "^5.0.13",
             "postcss-value-parser": "^3.2.3"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-convert-values": {
@@ -15214,6 +15602,54 @@
           "requires": {
             "postcss": "^5.0.11",
             "postcss-value-parser": "^3.1.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-discard-comments": {
@@ -15221,6 +15657,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.14"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-discard-duplicates": {
@@ -15228,6 +15712,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-discard-empty": {
@@ -15235,6 +15767,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.14"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-discard-overridden": {
@@ -15242,6 +15822,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.16"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-discard-unused": {
@@ -15250,6 +15878,54 @@
           "requires": {
             "postcss": "^5.0.14",
             "uniqs": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-filter-plugins": {
@@ -15257,30 +15933,64 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-import": {
+          "version": "11.1.0",
           "bundled": true,
           "requires": {
             "postcss": "^6.0.1",
             "postcss-value-parser": "^3.2.3",
             "read-cache": "^1.0.0",
             "resolve": "^1.1.7"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-load-config": {
@@ -15291,6 +16001,32 @@
             "object-assign": "^4.1.0",
             "postcss-load-options": "^1.2.0",
             "postcss-load-plugins": "^2.3.0"
+          },
+          "dependencies": {
+            "cosmiconfig": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.4.3",
+                "minimist": "^1.2.0",
+                "object-assign": "^4.1.0",
+                "os-homedir": "^1.0.1",
+                "parse-json": "^2.2.0",
+                "require-from-string": "^1.1.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "require-from-string": {
+              "version": "1.2.1",
+              "bundled": true
+            }
           }
         },
         "postcss-load-options": {
@@ -15299,6 +16035,32 @@
           "requires": {
             "cosmiconfig": "^2.1.0",
             "object-assign": "^4.1.0"
+          },
+          "dependencies": {
+            "cosmiconfig": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.4.3",
+                "minimist": "^1.2.0",
+                "object-assign": "^4.1.0",
+                "os-homedir": "^1.0.1",
+                "parse-json": "^2.2.0",
+                "require-from-string": "^1.1.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "require-from-string": {
+              "version": "1.2.1",
+              "bundled": true
+            }
           }
         },
         "postcss-load-plugins": {
@@ -15307,30 +16069,42 @@
           "requires": {
             "cosmiconfig": "^2.1.1",
             "object-assign": "^4.1.0"
+          },
+          "dependencies": {
+            "cosmiconfig": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.4.3",
+                "minimist": "^1.2.0",
+                "object-assign": "^4.1.0",
+                "os-homedir": "^1.0.1",
+                "parse-json": "^2.2.0",
+                "require-from-string": "^1.1.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "require-from-string": {
+              "version": "1.2.1",
+              "bundled": true
+            }
           }
         },
         "postcss-loader": {
+          "version": "2.1.5",
           "bundled": true,
           "requires": {
             "loader-utils": "^1.1.0",
             "postcss": "^6.0.0",
             "postcss-load-config": "^1.2.0",
             "schema-utils": "^0.4.0"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-merge-idents": {
@@ -15340,6 +16114,54 @@
             "has": "^1.0.1",
             "postcss": "^5.0.10",
             "postcss-value-parser": "^3.1.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-merge-longhand": {
@@ -15347,6 +16169,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-merge-rules": {
@@ -15358,6 +16228,62 @@
             "postcss": "^5.0.4",
             "postcss-selector-parser": "^2.2.2",
             "vendors": "^1.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "browserslist": {
+              "version": "1.7.7",
+              "bundled": true,
+              "requires": {
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-message-helpers": {
@@ -15371,6 +16297,54 @@
             "object-assign": "^4.0.1",
             "postcss": "^5.0.4",
             "postcss-value-parser": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-minify-gradients": {
@@ -15379,6 +16353,54 @@
           "requires": {
             "postcss": "^5.0.12",
             "postcss-value-parser": "^3.3.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-minify-params": {
@@ -15389,6 +16411,54 @@
             "postcss": "^5.0.2",
             "postcss-value-parser": "^3.0.2",
             "uniqs": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-minify-selectors": {
@@ -15399,6 +16469,54 @@
             "has": "^1.0.1",
             "postcss": "^5.0.14",
             "postcss-selector-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-modules-extract-imports": {
@@ -15406,21 +16524,6 @@
           "bundled": true,
           "requires": {
             "postcss": "^6.0.1"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-modules-local-by-default": {
@@ -15429,21 +16532,6 @@
           "requires": {
             "css-selector-tokenizer": "^0.7.0",
             "postcss": "^6.0.1"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-modules-scope": {
@@ -15452,21 +16540,6 @@
           "requires": {
             "css-selector-tokenizer": "^0.7.0",
             "postcss": "^6.0.1"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-modules-values": {
@@ -15475,21 +16548,6 @@
           "requires": {
             "icss-replace-symbols": "^1.1.0",
             "postcss": "^6.0.1"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-normalize-charset": {
@@ -15497,6 +16555,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.5"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-normalize-url": {
@@ -15509,19 +16615,51 @@
             "postcss-value-parser": "^3.2.3"
           },
           "dependencies": {
-            "normalize-url": {
-              "version": "1.9.1",
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
               "bundled": true,
               "requires": {
-                "object-assign": "^4.0.1",
-                "prepend-http": "^1.0.0",
-                "query-string": "^4.1.0",
-                "sort-keys": "^1.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
               }
             },
-            "prepend-http": {
-              "version": "1.0.4",
+            "has-flag": {
+              "version": "1.0.0",
               "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
             }
           }
         },
@@ -15531,6 +16669,54 @@
           "requires": {
             "postcss": "^5.0.4",
             "postcss-value-parser": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-reduce-idents": {
@@ -15539,6 +16725,54 @@
           "requires": {
             "postcss": "^5.0.4",
             "postcss-value-parser": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-reduce-initial": {
@@ -15546,6 +16780,54 @@
           "bundled": true,
           "requires": {
             "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-reduce-transforms": {
@@ -15555,6 +16837,54 @@
             "has": "^1.0.1",
             "postcss": "^5.0.8",
             "postcss-value-parser": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-selector-parser": {
@@ -15574,6 +16904,54 @@
             "postcss": "^5.0.14",
             "postcss-value-parser": "^3.2.3",
             "svgo": "^0.7.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-unique-selectors": {
@@ -15583,9 +16961,58 @@
             "alphanum-sort": "^1.0.1",
             "postcss": "^5.0.4",
             "uniqs": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "postcss-url": {
+          "version": "7.3.2",
           "bundled": true,
           "requires": {
             "mime": "^1.4.1",
@@ -15593,21 +17020,6 @@
             "mkdirp": "^0.5.0",
             "postcss": "^6.0.1",
             "xxhashjs": "^0.2.1"
-          },
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.22",
-              "bundled": true,
-              "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "postcss-value-parser": {
@@ -15621,6 +17033,54 @@
             "has": "^1.0.1",
             "postcss": "^5.0.4",
             "uniqs": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
           }
         },
         "prelude-ls": {
@@ -15628,7 +17088,7 @@
           "bundled": true
         },
         "prepend-http": {
-          "version": "2.0.0",
+          "version": "1.0.4",
           "bundled": true
         },
         "preserve": {
@@ -15645,12 +17105,6 @@
           "requires": {
             "renderkid": "^2.0.1",
             "utila": "~0.4"
-          },
-          "dependencies": {
-            "utila": {
-              "version": "0.4.0",
-              "bundled": true
-            }
           }
         },
         "private": {
@@ -15666,7 +17120,7 @@
           "bundled": true
         },
         "progress": {
-          "version": "1.1.8",
+          "version": "2.0.0",
           "bundled": true
         },
         "promise": {
@@ -15750,6 +17204,7 @@
           }
         },
         "pug": {
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
             "pug-code-gen": "^2.0.1",
@@ -15800,6 +17255,21 @@
             "pug-walk": "^1.1.7",
             "resolve": "^1.1.6",
             "uglify-js": "^2.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              }
+            }
           }
         },
         "pug-lexer": {
@@ -15836,6 +17306,7 @@
           }
         },
         "pug-plain-loader": {
+          "version": "1.0.0",
           "bundled": true,
           "requires": {
             "loader-utils": "^1.1.0"
@@ -15925,10 +17396,6 @@
             "is-number": {
               "version": "4.0.0",
               "bundled": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true
             }
           }
         },
@@ -15976,6 +17443,12 @@
           "bundled": true,
           "requires": {
             "pify": "^2.3.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
           }
         },
         "read-pkg": {
@@ -15988,71 +17461,11 @@
           }
         },
         "read-pkg-up": {
-          "version": "1.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "load-json-file": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
-              }
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "error-ex": "^1.2.0"
-              }
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "^0.2.0"
-              }
-            }
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "readable-stream": {
@@ -16066,15 +17479,6 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
           }
         },
         "readdirp": {
@@ -16142,6 +17546,12 @@
             "balanced-match": "^0.4.2",
             "math-expression-evaluator": "^1.2.14",
             "reduce-function-call": "^1.0.1"
+          },
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            }
           }
         },
         "reduce-function-call": {
@@ -16149,6 +17559,12 @@
           "bundled": true,
           "requires": {
             "balanced-match": "^0.4.2"
+          },
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            }
           }
         },
         "regenerate": {
@@ -16156,7 +17572,7 @@
           "bundled": true
         },
         "regenerator-runtime": {
-          "version": "0.10.5",
+          "version": "0.11.1",
           "bundled": true
         },
         "regenerator-transform": {
@@ -16181,23 +17597,6 @@
           "requires": {
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
-              }
-            },
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
           }
         },
         "regexpp": {
@@ -16205,7 +17604,7 @@
           "bundled": true
         },
         "regexpu-core": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
             "regenerate": "^1.2.1",
@@ -16255,6 +17654,12 @@
             "htmlparser2": "~3.3.0",
             "strip-ansi": "^3.0.0",
             "utila": "~0.3"
+          },
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true
+            }
           }
         },
         "repeat-element": {
@@ -16314,13 +17719,6 @@
             "lodash": "^4.15.0",
             "request": "^2.74.0",
             "when": "^3.7.7"
-          },
-          "dependencies": {
-            "when": {
-              "version": "3.7.8",
-              "bundled": true,
-              "optional": true
-            }
           }
         },
         "require-directory": {
@@ -16328,7 +17726,7 @@
           "bundled": true
         },
         "require-from-string": {
-          "version": "1.2.1",
+          "version": "2.0.2",
           "bundled": true
         },
         "require-main-filename": {
@@ -16503,6 +17901,10 @@
                 "uri-js": "^4.2.1"
               }
             },
+            "ajv-keywords": {
+              "version": "3.2.0",
+              "bundled": true
+            },
             "fast-deep-equal": {
               "version": "2.0.1",
               "bundled": true
@@ -16525,6 +17927,7 @@
           }
         },
         "semantic-release": {
+          "version": "15.6.0",
           "bundled": true,
           "requires": {
             "@semantic-release/commit-analyzer": "^5.0.0",
@@ -16584,6 +17987,13 @@
                 "ms": "2.0.0"
               }
             },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
             "locate-path": {
               "version": "3.0.0",
               "bundled": true,
@@ -16592,21 +18002,30 @@
                 "path-exists": "^3.0.0"
               }
             },
+            "p-limit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
             "read-pkg-up": {
               "version": "4.0.0",
               "bundled": true,
               "requires": {
                 "find-up": "^3.0.0",
                 "read-pkg": "^3.0.0"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "locate-path": "^3.0.0"
-                  }
-                }
               }
             },
             "strip-ansi": {
@@ -16615,6 +18034,10 @@
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
             },
             "yargs": {
               "version": "11.0.0",
@@ -16632,13 +18055,41 @@
                 "which-module": "^2.0.0",
                 "y18n": "^3.2.1",
                 "yargs-parser": "^9.0.2"
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "bundled": true,
-              "requires": {
-                "camelcase": "^4.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "^2.0.0"
+                  }
+                },
+                "locate-path": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-locate": "^2.0.0",
+                    "path-exists": "^3.0.0"
+                  }
+                },
+                "p-limit": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-try": "^1.0.0"
+                  }
+                },
+                "p-locate": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-limit": "^1.1.0"
+                  }
+                },
+                "p-try": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
               }
             }
           }
@@ -16672,6 +18123,10 @@
           "dependencies": {
             "mime": {
               "version": "1.4.1",
+              "bundled": true
+            },
+            "statuses": {
+              "version": "1.4.0",
               "bundled": true
             }
           }
@@ -16719,6 +18174,15 @@
             "is-extendable": "^0.1.1",
             "is-plain-object": "^2.0.3",
             "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "setimmediate": {
@@ -16749,6 +18213,7 @@
           "bundled": true
         },
         "shelljs": {
+          "version": "0.8.2",
           "bundled": true,
           "requires": {
             "glob": "^7.0.0",
@@ -16765,6 +18230,7 @@
           "bundled": true
         },
         "sinon": {
+          "version": "4.5.0",
           "bundled": true,
           "requires": {
             "@sinonjs/formatio": "^2.0.0",
@@ -16774,9 +18240,16 @@
             "nise": "^1.2.0",
             "supports-color": "^5.1.0",
             "type-detect": "^4.0.5"
+          },
+          "dependencies": {
+            "lolex": {
+              "version": "2.7.0",
+              "bundled": true
+            }
           }
         },
         "sinon-chai": {
+          "version": "3.2.0",
           "bundled": true
         },
         "slack-node": {
@@ -16822,6 +18295,26 @@
             "source-map": "^0.5.6",
             "source-map-resolve": "^0.5.0",
             "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "snapdragon-node": {
@@ -16839,6 +18332,29 @@
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
             }
           }
         },
@@ -16847,6 +18363,15 @@
           "bundled": true,
           "requires": {
             "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "sntp": {
@@ -16944,12 +18469,11 @@
           }
         },
         "socks": {
-          "version": "1.1.9",
+          "version": "1.1.10",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "ip": "^1.1.2",
-            "smart-buffer": "^1.0.4"
+            "ip": "^1.1.4",
+            "smart-buffer": "^1.0.13"
           }
         },
         "socks-proxy-agent": {
@@ -16958,16 +18482,6 @@
           "requires": {
             "agent-base": "^4.1.0",
             "socks": "^1.1.10"
-          },
-          "dependencies": {
-            "socks": {
-              "version": "1.1.10",
-              "bundled": true,
-              "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
-              }
-            }
           }
         },
         "sort-keys": {
@@ -16982,7 +18496,7 @@
           "bundled": true
         },
         "source-map": {
-          "version": "0.5.7",
+          "version": "0.6.1",
           "bundled": true
         },
         "source-map-resolve": {
@@ -17001,6 +18515,12 @@
           "bundled": true,
           "requires": {
             "source-map": "^0.5.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
           }
         },
         "source-map-url": {
@@ -17072,23 +18592,6 @@
           "bundled": true,
           "requires": {
             "extend-shallow": "^3.0.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
-              }
-            },
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
           }
         },
         "split2": {
@@ -17134,10 +18637,19 @@
           "requires": {
             "define-property": "^0.2.5",
             "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
           }
         },
         "statuses": {
-          "version": "1.4.0",
+          "version": "1.5.0",
           "bundled": true
         },
         "stream-browserify": {
@@ -17165,7 +18677,7 @@
           }
         },
         "stream-http": {
-          "version": "2.8.2",
+          "version": "2.8.3",
           "bundled": true,
           "requires": {
             "builtin-status-codes": "^3.0.0",
@@ -17224,8 +18736,11 @@
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "bundled": true
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         },
         "stringstream": {
           "version": "0.0.6",
@@ -17256,6 +18771,7 @@
           "bundled": true
         },
         "stylus": {
+          "version": "0.54.5",
           "bundled": true,
           "requires": {
             "css-parse": "1.7.x",
@@ -17266,13 +18782,6 @@
             "source-map": "0.1.x"
           },
           "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "glob": {
               "version": "7.0.6",
               "bundled": true,
@@ -17299,11 +18808,18 @@
           }
         },
         "stylus-loader": {
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "loader-utils": "^1.0.2",
             "lodash.clonedeep": "^4.5.0",
             "when": "~3.6.x"
+          },
+          "dependencies": {
+            "when": {
+              "version": "3.6.4",
+              "bundled": true
+            }
           }
         },
         "supports-color": {
@@ -17311,12 +18827,6 @@
           "bundled": true,
           "requires": {
             "has-flag": "^3.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
         "svgo": {
@@ -17332,8 +18842,8 @@
             "whet.extend": "~0.9.9"
           },
           "dependencies": {
-            "colors": {
-              "version": "1.1.2",
+            "esprima": {
+              "version": "2.7.3",
               "bundled": true
             },
             "js-yaml": {
@@ -17356,16 +18866,10 @@
             "lodash": "^4.17.4",
             "slice-ansi": "1.0.0",
             "string-width": "^2.1.1"
-          },
-          "dependencies": {
-            "ajv-keywords": {
-              "version": "2.1.1",
-              "bundled": true
-            }
           }
         },
         "tapable": {
-          "version": "0.2.8",
+          "version": "0.1.10",
           "bundled": true
         },
         "test-exclude": {
@@ -17377,6 +18881,78 @@
             "object-assign": "^4.1.0",
             "read-pkg-up": "^1.0.1",
             "require-main-filename": "^1.0.1"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            }
           }
         },
         "text-encoding": {
@@ -17460,6 +19036,15 @@
           "bundled": true,
           "requires": {
             "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "to-regex": {
@@ -17470,31 +19055,6 @@
             "extend-shallow": "^3.0.2",
             "regex-not": "^1.0.2",
             "safe-regex": "^1.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
-              }
-            },
-            "extend-shallow": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
-              }
-            },
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
           }
         },
         "to-regex-range": {
@@ -17584,60 +19144,12 @@
           "version": "0.0.6",
           "bundled": true
         },
-        "uglify-es": {
-          "version": "3.3.9",
-          "bundled": true,
-          "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.13.0",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
-          }
-        },
         "uglify-js": {
-          "version": "2.8.29",
+          "version": "3.3.28",
           "bundled": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "center-align": "^0.1.1",
-                "right-align": "^0.1.1",
-                "wordwrap": "0.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
-            }
+            "commander": "~2.15.0",
+            "source-map": "~0.6.1"
           }
         },
         "uglify-to-browserify": {
@@ -17646,6 +19158,7 @@
           "optional": true
         },
         "uglifyjs-webpack-plugin": {
+          "version": "1.2.6",
           "bundled": true,
           "requires": {
             "cacache": "^10.0.4",
@@ -17658,9 +19171,17 @@
             "worker-farm": "^1.5.2"
           },
           "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
+            "commander": {
+              "version": "2.13.0",
               "bundled": true
+            },
+            "uglify-es": {
+              "version": "3.3.9",
+              "bundled": true,
+              "requires": {
+                "commander": "~2.13.0",
+                "source-map": "~0.6.1"
+              }
             }
           }
         },
@@ -17682,6 +19203,13 @@
             "set-value": "^0.4.3"
           },
           "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
             "set-value": {
               "version": "0.4.3",
               "bundled": true,
@@ -17800,6 +19328,7 @@
           "bundled": true
         },
         "url-loader": {
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "loader-utils": "^1.1.0",
@@ -17826,6 +19355,12 @@
           "bundled": true,
           "requires": {
             "prepend-http": "^2.0.0"
+          },
+          "dependencies": {
+            "prepend-http": {
+              "version": "2.0.0",
+              "bundled": true
+            }
           }
         },
         "url-template": {
@@ -17841,12 +19376,6 @@
           "bundled": true,
           "requires": {
             "kind-of": "^6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true
-            }
           }
         },
         "useragent": {
@@ -17883,7 +19412,7 @@
           }
         },
         "utila": {
-          "version": "0.3.3",
+          "version": "0.4.0",
           "bundled": true
         },
         "utils-merge": {
@@ -17926,12 +19455,6 @@
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
             "extsprintf": "^1.2.0"
-          },
-          "dependencies": {
-            "extsprintf": {
-              "version": "1.4.0",
-              "bundled": true
-            }
           }
         },
         "vm-browserify": {
@@ -17983,6 +19506,7 @@
           "bundled": true
         },
         "vue-loader": {
+          "version": "15.2.4",
           "bundled": true,
           "requires": {
             "@vue/component-compiler-utils": "^1.2.1",
@@ -17993,6 +19517,7 @@
           }
         },
         "vue-router": {
+          "version": "3.0.1",
           "bundled": true
         },
         "vue-style-loader": {
@@ -18004,6 +19529,7 @@
           }
         },
         "vue-template-compiler": {
+          "version": "2.5.16",
           "bundled": true,
           "requires": {
             "de-indent": "^1.0.2",
@@ -18015,7 +19541,7 @@
           "bundled": true
         },
         "vuetify": {
-          "version": "1.0.19",
+          "version": "1.1.4",
           "bundled": true
         },
         "watchpack": {
@@ -18025,6 +19551,58 @@
             "chokidar": "^2.0.2",
             "graceful-fs": "^4.1.2",
             "neo-async": "^2.5.0"
+          },
+          "dependencies": {
+            "anymatch": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+              }
+            },
+            "chokidar": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
           }
         },
         "wbuf": {
@@ -18042,6 +19620,7 @@
           }
         },
         "webpack": {
+          "version": "3.12.0",
           "bundled": true,
           "requires": {
             "acorn": "^5.0.0",
@@ -18068,10 +19647,6 @@
             "yargs": "^8.0.2"
           },
           "dependencies": {
-            "acorn": {
-              "version": "5.7.1",
-              "bundled": true
-            },
             "ajv": {
               "version": "6.5.1",
               "bundled": true,
@@ -18082,9 +19657,38 @@
                 "uri-js": "^4.2.1"
               }
             },
+            "ajv-keywords": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "enhanced-resolve": {
+              "version": "3.4.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "object-assign": "^4.0.1",
+                "tapable": "^0.2.7"
+              }
+            },
             "fast-deep-equal": {
               "version": "2.0.1",
               "bundled": true
+            },
+            "has-flag": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
             },
             "json-schema-traverse": {
               "version": "0.4.1",
@@ -18100,6 +19704,14 @@
                 "strip-bom": "^3.0.0"
               }
             },
+            "memory-fs": {
+              "version": "0.4.1",
+              "bundled": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            },
             "parse-json": {
               "version": "2.2.0",
               "bundled": true,
@@ -18113,6 +19725,10 @@
               "requires": {
                 "pify": "^2.0.0"
               }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
             },
             "read-pkg": {
               "version": "2.0.0",
@@ -18131,11 +19747,40 @@
                 "read-pkg": "^2.0.0"
               }
             },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
             "supports-color": {
               "version": "4.5.0",
               "bundled": true,
               "requires": {
                 "has-flag": "^2.0.0"
+              }
+            },
+            "tapable": {
+              "version": "0.2.8",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
+                    "window-size": "0.1.0"
+                  }
+                }
               }
             },
             "uglifyjs-webpack-plugin": {
@@ -18146,6 +19791,10 @@
                 "uglify-js": "^2.8.29",
                 "webpack-sources": "^1.0.1"
               }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
             },
             "yargs": {
               "version": "8.0.2",
@@ -18164,6 +19813,32 @@
                 "which-module": "^2.0.0",
                 "y18n": "^3.2.1",
                 "yargs-parser": "^7.0.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wrap-ansi": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                      }
+                    }
+                  }
+                }
               }
             },
             "yargs-parser": {
@@ -18171,11 +19846,18 @@
               "bundled": true,
               "requires": {
                 "camelcase": "^4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
               }
             }
           }
         },
         "webpack-bundle-analyzer": {
+          "version": "2.12.0",
           "bundled": true,
           "requires": {
             "acorn": "^5.3.0",
@@ -18192,10 +19874,6 @@
             "ws": "^4.0.0"
           },
           "dependencies": {
-            "acorn": {
-              "version": "5.7.1",
-              "bundled": true
-            },
             "ws": {
               "version": "4.1.0",
               "bundled": true,
@@ -18207,17 +19885,34 @@
           }
         },
         "webpack-dev-middleware": {
-          "version": "1.12.2",
+          "version": "2.0.6",
           "bundled": true,
           "requires": {
+            "loud-rejection": "^1.6.0",
             "memory-fs": "~0.4.1",
-            "mime": "^1.5.0",
+            "mime": "^2.1.0",
             "path-is-absolute": "^1.0.0",
             "range-parser": "^1.0.3",
-            "time-stamp": "^2.0.0"
+            "url-join": "^2.0.2",
+            "webpack-log": "^1.0.1"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.4.1",
+              "bundled": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            },
+            "mime": {
+              "version": "2.3.1",
+              "bundled": true
+            }
           }
         },
         "webpack-dev-server": {
+          "version": "2.11.2",
           "bundled": true,
           "requires": {
             "ansi-html": "0.0.7",
@@ -18249,11 +19944,257 @@
             "yargs": "6.6.0"
           },
           "dependencies": {
+            "anymatch": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+              }
+            },
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "chokidar": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
+              }
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
             "debug": {
               "version": "3.1.0",
               "bundled": true,
               "requires": {
                 "ms": "2.0.0"
+              }
+            },
+            "del": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
+              }
+            },
+            "globby": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "memory-fs": {
+              "version": "0.4.1",
+              "bundled": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "lcid": "^1.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            },
+            "webpack-dev-middleware": {
+              "version": "1.12.2",
+              "bundled": true,
+              "requires": {
+                "memory-fs": "~0.4.1",
+                "mime": "^1.5.0",
+                "path-is-absolute": "^1.0.0",
+                "range-parser": "^1.0.3",
+                "time-stamp": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "6.6.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^4.2.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^3.0.0"
               }
             }
           }
@@ -18269,6 +20210,7 @@
           }
         },
         "webpack-merge": {
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
             "lodash": "^4.17.5"
@@ -18280,12 +20222,6 @@
           "requires": {
             "source-list-map": "^2.0.0",
             "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true
-            }
           }
         },
         "websocket-driver": {
@@ -18301,8 +20237,9 @@
           "bundled": true
         },
         "when": {
-          "version": "3.6.4",
-          "bundled": true
+          "version": "3.7.8",
+          "bundled": true,
+          "optional": true
         },
         "whet.extend": {
           "version": "0.9.9",
@@ -18424,72 +20361,34 @@
           }
         },
         "y18n": {
-          "version": "3.2.1",
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
           "bundled": true
         },
         "yargs": {
-          "version": "6.6.0",
+          "version": "3.10.0",
           "bundled": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
           },
           "dependencies": {
             "camelcase": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lcid": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "which-module": {
-              "version": "1.0.0",
+              "version": "1.2.1",
               "bundled": true
             }
           }
         },
         "yargs-parser": {
-          "version": "4.2.1",
+          "version": "9.0.2",
           "bundled": true,
           "requires": {
-            "camelcase": "^3.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true
-            }
+            "camelcase": "^4.1.0"
           }
         },
         "yauzl": {
@@ -19498,9 +21397,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -19552,9 +21451,9 @@
       "dev": true
     },
     "vue-loader": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.7.1.tgz",
-      "integrity": "sha512-v6PbKMGl/hWHGPxB2uGHsA66vusrXF66J/h1QiFXtU6z5zVSK8jq5xl95M1p3QNXmuEJKNP3nxoXfbgQNs7hJg==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.7.2.tgz",
+      "integrity": "sha512-pgFWFsUjYO1v+J+3r7K0Q4lCp0eOyI24/q9j+cCudWyCTjgpjpcAa1MdwjlDUUettt9xkkUBbQ9fkAN1NC8t9w==",
       "dev": true,
       "requires": {
         "consolidate": "^0.14.0",
@@ -19592,11 +21491,41 @@
             "supports-color": "^5.3.0"
           }
         },
+        "cosmiconfig": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+          "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+          "dev": true,
+          "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
         },
         "postcss": {
           "version": "6.0.23",
@@ -19608,6 +21537,24 @@
             "source-map": "^0.6.1",
             "supports-color": "^5.4.0"
           }
+        },
+        "postcss-load-config": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+          "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+          "dev": true,
+          "requires": {
+            "cosmiconfig": "^2.1.0",
+            "object-assign": "^4.1.0",
+            "postcss-load-options": "^1.2.0",
+            "postcss-load-plugins": "^2.3.0"
+          }
+        },
+        "require-from-string": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -19673,9 +21620,9 @@
       }
     },
     "webpack": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
-      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
+      "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
       "dev": true,
       "requires": {
         "acorn": "^5.0.0",
@@ -19886,6 +21833,15 @@
           "dev": true,
           "requires": {
             "lcid": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {

--- a/examples/girder/src/main.js
+++ b/examples/girder/src/main.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import ResonantGeo from 'resonantgeo';
-import { Session } from 'resonantgeo/rest';
+import { Session } from 'resonantgeo/src/rest';
 
 import App from './App';
 

--- a/examples/girder/webpack.config.js
+++ b/examples/girder/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      vue$: 'vue/dist/vue.esm.js',
+      vue$: require.resolve('vue/dist/vue.esm.js'),
     },
     extensions: ['*', '.js', '.vue', '.json'],
   },

--- a/examples/layout/package-lock.json
+++ b/examples/layout/package-lock.json
@@ -6841,9 +6841,9 @@
       "version": "file:../..",
       "requires": {
         "geojs": "^0.16.0",
-        "lodash-es": "^4.17.8",
-        "vue": "^2.5.2",
-        "vuetify": "^1.0.0"
+        "lodash-es": "^4.17.10",
+        "vue": "^2.5.16",
+        "vuetify": "1.1.4"
       },
       "dependencies": {
         "babel-plugin-transform-runtime": {

--- a/examples/layout/webpack.config.js
+++ b/examples/layout/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      vue$: 'vue/dist/vue.esm.js',
+      vue$: require.resolve('vue/dist/vue.esm.js'),
     },
     extensions: ['*', '.js', '.vue', '.json'],
   },
@@ -54,6 +54,9 @@ module.exports = {
     hints: false,
   },
   devtool: '#eval-source-map',
+  plugins: [
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+  ],
 };
 
 if (process.env.NODE_ENV === 'production') {

--- a/examples/layout/yarn.lock
+++ b/examples/layout/yarn.lock
@@ -228,6 +228,13 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2003,6 +2010,12 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.1.0"
 
+follow-redirects@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.1.tgz#67a8f14f5a1f67f962c2c46469c79eaec0a90291"
+  dependencies:
+    debug "^3.1.0"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2672,6 +2685,10 @@ isobject@^3.0.0, isobject@^3.0.1:
 js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
+
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
 
 js-stringify@^1.0.1:
   version "1.0.2"
@@ -3942,6 +3959,10 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+qs@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -4197,10 +4218,16 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0:
 "resonantgeo@file:../..":
   version "0.0.0-semantically-released"
   dependencies:
+    axios "^0.18.0"
     geojs "^0.16.0"
+    js-cookie "^2.2.0"
     lodash-es "^4.17.10"
+    qs "^6.5.2"
+    vee-validate "^2.1.0-beta.2"
     vue "^2.5.16"
-    vuetify "1.0.14"
+    vue-async-computed "^3.3.1"
+    vue-avatar "^2.1.5"
+    vuetify "1.1.4"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -4872,6 +4899,10 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
+vee-validate@^2.1.0-beta.2:
+  version "2.1.0-beta.6"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-2.1.0-beta.6.tgz#df67af3b87f45f4c82c19783d782a8415cb375ce"
+
 vendors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
@@ -4885,6 +4916,14 @@ vm-browserify@0.0.4:
 void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+
+vue-async-computed@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/vue-async-computed/-/vue-async-computed-3.3.1.tgz#9d754e649ccabef97e7e3932f1bc097a66a23db7"
+
+vue-avatar@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/vue-avatar/-/vue-avatar-2.1.5.tgz#ae867ea3897a79aa9e532c3d0741f8786c4bb656"
 
 vue-hot-reload-api@^2.2.0:
   version "2.3.0"
@@ -4934,9 +4973,9 @@ vue@^2.5.11, vue@^2.5.16:
   version "2.5.16"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
 
-vuetify@1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.0.14.tgz#ab1f0e702383f66f9d320fd8e1cd2d63e7871e0b"
+vuetify@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.1.4.tgz#2fd50f38a580bfe51c346d273a8d88fad4144302"
 
 watchpack@^1.4.0:
   version "1.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16550,9 +16550,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.0.18.tgz",
-      "integrity": "sha512-adOZaSCgoeGgyL3bgm0bpAfbUJWQ9WVD6CBpJriQJ6JUMaKNoEvKnuhY5LGRlR209QOx4LB8e6HBlKtGwbFtIA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.1.4.tgz",
+      "integrity": "sha512-BJhkFv2pVDQTT4N8WhIwicyVFwA0fjsIV771+eoR0mLFtVk9beM5Ii0L4HcSQIIVepmWzuLsEbqmmqCdOkw5og=="
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vue": "^2.5.16",
     "vue-async-computed": "^3.3.1",
     "vue-avatar": "^2.1.5",
-    "vuetify": "1.0.19"
+    "vuetify": "1.1.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.2.0",

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-v-toolbar(app, tabs)
+v-toolbar.resonantgeo-toolbar(app, tabs)
   slot(name='left')
     v-tabs.mx-0(
       v-if='tabs.length',
@@ -30,11 +30,17 @@ v-toolbar(app, tabs)
 </template>
 
 <style lang="stylus" scoped>
-.tabs
+.v-tabs
   width unset
 
   .tab
     min-width 100px
+</style>
+
+<style lang="stylus">
+.resonantgeo-toolbar
+  .v-toolbar__content
+    padding 0
 </style>
 
 <script>

--- a/test/specs/SidePanel.spec.js
+++ b/test/specs/SidePanel.spec.js
@@ -23,8 +23,8 @@ describe('SidePanel.vue', () => {
         },
       },
     });
-    expect(wrapper.contains('.toolbar')).to.equal(true);
-    expect(wrapper.find('.toolbar').text()).to.equal('Toolbar title');
+    expect(wrapper.contains('.v-toolbar')).to.equal(true);
+    expect(wrapper.find('.v-toolbar').text()).to.equal('Toolbar title');
   });
 
   it('toolbar with icon', () => {
@@ -36,8 +36,8 @@ describe('SidePanel.vue', () => {
         },
       },
     });
-    expect(wrapper.contains('.toolbar')).to.equal(true);
-    expect(wrapper.find('.toolbar button').text()).to.equal('more_vert');
+    expect(wrapper.contains('.v-toolbar')).to.equal(true);
+    expect(wrapper.find('.v-toolbar button').text()).to.equal('more_vert');
   });
 
   it('right side panel', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9096,9 +9096,9 @@ vue@^2.5.16:
   version "2.5.16"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
 
-vuetify@1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.0.19.tgz#fb6d123dd1c217795fc2333e912c0ecbed2ed69e"
+vuetify@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.1.4.tgz#2fd50f38a580bfe51c346d273a8d88fad4144302"
 
 watchpack@^1.4.0:
   version "1.6.0"


### PR DESCRIPTION
This is needed for some features of the DataTable component added recently.  There is a possibility of some style related incompatibilities for downstream users.
* All element classes are now prefixed with `v-`.  Any global styles modifying vuetify elements will likely need changes to the selectors.
* I had to change how `vue` is aliased to ensure that it isn't duplicated in the bundle.  This may just be an artifact of how resonantgeo is symlinked into place for the builtin examples.