### PR TITLE
Prefer normal constructor semantics in Session

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -70,23 +70,24 @@ const mixin = {
 };
 
 function Session({ apiRoot = '/api/v1', token = cookies.get('girderToken'), axios = axios_.create() } = {}) {
-  const instance = Object.assign(
+  Object.assign(
     this,
     axios,
     mixin,
     { token, apiRoot },
   );
 
-  instance.interceptors.request.use((config) => {
-    const headers = Object.assign({
-      'Girder-Token': instance.token,
-    }, config.headers);
-    return Object.assign({}, config, {
-      baseURL: instance.apiRoot,
+  axios.interceptors.request.use((config) => {
+    const headers = {
+      'Girder-Token': this.token,
+      ...config.headers,
+    };
+    return {
+      ...config,
+      baseURL: this.apiRoot,
       headers,
-    });
+    };
   });
-  return instance;
 }
 
 export {


### PR DESCRIPTION
Constructors should only have an explicit return value in non-standard scenarios where they wish to return something other than `this`.