### PR TITLE
feat(geojs): add GeojsColorLegendWidget component

### DIFF
--- a/examples/layout/src/MapView.vue
+++ b/examples/layout/src/MapView.vue
@@ -31,6 +31,10 @@ full-screen-viewport
       :zIndex='3'
     )
       v-btn(color='success') Clifton Park
+    geojs-color-legend-widget(
+      :zIndex='100',
+      :categories='categories'
+    )
 
   side-panel(
     :floating='false',
@@ -164,6 +168,15 @@ export default {
         position: [-73.7569, 42.8495],
         offset: [0, -30],
       },
+      categories: [
+        {
+          name: 'Discrete ordinal',
+          type: 'discrete',
+          scale: 'ordinal',
+          domain: ['beijing', 'new york', 'london', 'paris'],
+          colors: ['red', 'green', 'blue', 'orange'],
+        },
+      ],
     };
   },
   methods: {

--- a/src/components/geojs/GeojsColorLegendWidget.vue
+++ b/src/components/geojs/GeojsColorLegendWidget.vue
@@ -1,0 +1,43 @@
+<script>
+import layerMixin from '../../mixins/geojsLayer';
+
+export default {
+  mixins: [layerMixin],
+  props: {
+    categories: {
+      type: Array,
+      required: true,
+    },
+    position: {
+      type: Object,
+      default() {
+        return {
+          right: 10,
+          top: 10,
+        };
+      },
+    },
+  },
+  watch: {
+    categories: {
+      handler(newValue, oldValue) {
+        this.colorLegend.removeCategories(oldValue);
+        this.colorLegend.addCategories(newValue);
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    this.createLayer('ui', {
+      opacity: this.opacity,
+    });
+    this.colorLegend = this.$geojsLayer.createWidget('colorLegend', {
+      position: this.position,
+    });
+    this.colorLegend.addCategories(this.categories);
+  },
+  render() {
+    return null;
+  },
+};
+</script>

--- a/src/components/geojs/index.js
+++ b/src/components/geojs/index.js
@@ -4,6 +4,7 @@ import GeojsHeatmapLayer from './GeojsHeatmapLayer';
 import GeojsMapViewport from './GeojsMapViewport';
 import GeojsTileLayer from './GeojsTileLayer';
 import GeojsWidgetLayer from './GeojsWidgetLayer';
+import GeojsColorLegendWidget from './GeojsColorLegendWidget';
 import * as utils from './utils';
 
 export {
@@ -13,5 +14,6 @@ export {
   GeojsMapViewport,
   GeojsTileLayer,
   GeojsWidgetLayer,
+  GeojsColorLegendWidget,
   utils,
 };

--- a/test/specs/GeojsColorLegendWidget.spec.js
+++ b/test/specs/GeojsColorLegendWidget.spec.js
@@ -1,0 +1,81 @@
+import GeojsColorLegendWidget from '@/components/geojs/GeojsColorLegendWidget';
+
+import ProvideGeojs from '../ProvideGeojs';
+
+describe('GeojsColorLegendWidget.vue', () => {
+  const provider = new ProvideGeojs();
+  function mountLayer(options = {}) {
+    return provider.mountLayer(GeojsColorLegendWidget, options);
+  }
+
+  beforeEach(() => {
+    sinon.stub(console, 'warn');
+    provider.start();
+  });
+  afterEach(() => {
+    console.warn.restore(); // eslint-disable-line no-console
+    provider.stop();
+  });
+
+  it('mount with empty data', () => {
+    const propsData = {
+      categories: [],
+    };
+    const wrapper = mountLayer({
+      propsData,
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    expect(layer.children().length).to.equal(1);
+    const widget = layer.children()[0];
+    expect(widget.canvas().style.display).to.equal('none');
+  });
+
+  it('mount with data', () => {
+    const propsData = {
+      categories: [{
+        name: 'Discrete ordinal',
+        type: 'discrete',
+        scale: 'ordinal',
+        domain: ['beijing', 'new york', 'london', 'paris'],
+        colors: ['red', 'green', 'blue', 'orange'],
+      }],
+    };
+    const wrapper = mountLayer({
+      propsData,
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    const widget = layer.children()[0];
+    expect(widget.categories().length).to.equal(1);
+    expect(widget.categories()).to.eql(propsData.categories);
+  });
+
+  it('responds to data changes', () => {
+    const propsData = {
+      categories: [{
+        name: 'Discrete ordinal',
+        type: 'discrete',
+        scale: 'ordinal',
+        domain: ['beijing', 'new york', 'london', 'paris'],
+        colors: ['red', 'green', 'blue', 'orange'],
+      }],
+    };
+    const wrapper = mountLayer({
+      propsData,
+    });
+    propsData.categories.push({
+      name: 'Continuous pow',
+      type: 'continuous',
+      scale: 'pow',
+      exponent: 1.1,
+      domain: [100, 10000],
+      colors: ['red', 'blue'],
+    });
+
+    const layer = wrapper.vm.$geojsLayer;
+    const widget = layer.children()[0];
+    expect(widget.categories().length).to.equal(2);
+    expect(widget.canvas().getElementsByClassName('legend').length).to.equal(2);
+  });
+});


### PR DESCRIPTION
Add a GeojsColorLegendWidget that wraps GeoJS color legend widget. It  would be used as a child component of GeojsMapViewport.